### PR TITLE
Reactive-Streams TCK integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,10 @@
 	<version>0.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
+        <properties>
+                <!-- later versions -->
+                <surefire.version>2.15</surefire.version>
+        </properties>
 
 	<name>troilus-parent multimodule</name>
 	<modules>
@@ -79,6 +83,17 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+                <plugins>
+                       <plugin>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>${surefire.version}</version>
+                              <configuration>
+                              <!-- Set this to "true" to redirect the unit test standard output to a file 
+                                    (found in reportsDirectory/testName-output.txt). -->
+                                       <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                              </configuration>
+                       </plugin>
+                </plugins>
 	</build>
 </project>
 

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
@@ -434,8 +434,6 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
                              }
                          }
 
-                     } else { 
-                         subscriber.onError(new IllegalStateException("already closed"));
                      }
                  }
              }
@@ -444,7 +442,7 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
              private void requestDatabaseForMoreRecords() {
                  // no more data to fetch?
                  if (rs.isFullyFetched()) {
-                     terminateRegularly();
+                     terminateRegularly(true);
                      return;
                  } 
                  
@@ -470,7 +468,7 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
              
              @Override
              public void cancel() {
-                 terminateRegularly();
+                 terminateRegularly(false);
              }
 
              
@@ -478,11 +476,11 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
              ////////////
              // terminate methods: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no further signals occur
              
-             private void terminateRegularly() {
+             private void terminateRegularly(boolean signalOnComplete) {
                  synchronized (subscriberCallbackLock) {
                      if (isOpen) {
                          isOpen = false;
-                         subscriber.onComplete();
+                         if(signalOnComplete) subscriber.onComplete();
                      }
                  }
              }

--- a/troilus-core/pom.xml
+++ b/troilus-core/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>troilus-core</artifactId>
 	<packaging>jar</packaging>
-
+    
 	<dependencies>
 		<dependency>
 			<groupId>net.oneandone.troilus</groupId>
@@ -24,13 +24,27 @@
 			<version>2.1.0</version>
 			<scope>test</scope>
 		</dependency>
-		
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        		
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>2.0.3-beta</version>
 			<scope>test</scope>
-		</dependency>		
+		</dependency>
+        		
+        <dependency>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams-tck</artifactId>
+          <version>1.0.0.RC1</version>
+          <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 
@@ -45,6 +59,25 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+            
+            <!-- Settings required to mix junit and testng tests -->
+            <!-- https://solidsoft.wordpress.com/2013/03/12/mixing-testng-and-junit-tests-in-one-maven-module-2013-edition/ -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            
 		</plugins>
 	</build>
 </project>

--- a/troilus-core/src/test/java/net/oneandone/troilus/reactive/PublisherTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/reactive/PublisherTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1&1 Internet AG, https://github.com/1and1/
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.oneandone.troilus.reactive;
+
+import java.io.IOException;
+
+import net.oneandone.troilus.Dao;
+import net.oneandone.troilus.DaoImpl;
+import net.oneandone.troilus.EmbeddedCassandra;
+import net.oneandone.troilus.Record;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableSet;
+
+
+@Test
+public class PublisherTest extends PublisherVerification<Record> {
+    
+    private static final String KEYYSPACENAME = "testks";
+    private static final String CREATE_STMT = "CREATE TABLE publisher_test (table_id int  PRIMARY KEY)";
+    
+    private Cluster cluster;
+    private Session session;
+    
+    @BeforeTest
+    public void setup() throws IOException {
+        EmbeddedCassandra.start();
+        
+        cluster = Cluster.builder()
+                         .addContactPointsWithPorts(ImmutableSet.of(EmbeddedCassandra.getNodeaddress()))
+                         .build();
+        
+        dropKeyspace(cluster);
+        createKeyspace(cluster);
+        
+        session = cluster.connect(KEYYSPACENAME);
+        session.execute(CREATE_STMT);
+        
+        
+    }
+
+    @AfterTest
+    public void teardown() {
+        session.close();
+        cluster.close();
+    }    
+    
+    public PublisherTest() {
+        super(new TestEnvironment(1000), 1000);
+    }
+
+    @Override
+    public Publisher<Record> createPublisher(long elements) {
+        try {
+            Dao dao = new DaoImpl(session, "publisher_test");
+            for(int i = 0; i < elements; i++) {
+                dao.writeWithKey("table_id", i).execute();
+            }
+            return dao.readAll().columns("table_id").execute();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 100l;
+    }
+
+    @Override
+    public Publisher<Record> createErrorStatePublisher() {
+        return null;
+    }
+    
+    private static final void dropKeyspace(Cluster cluster) {
+        try (Session session = cluster.connect("system")) {
+            session.execute("drop keyspace " + KEYYSPACENAME);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private static void createKeyspace(Cluster cluster) {
+        try (Session session = cluster.connect("system")) {
+            session.execute("create keyspace " + KEYYSPACENAME + " WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+        }
+    }
+    
+}


### PR DESCRIPTION
The reactive streams TCK can be used to check whether the implementation follows the spec. Its basically a set of tests that can be extended and executed along with the project specific tests. Since the tck tests are based on testng some modifications to the maven surefire plugin config had to be done to ensure that both testng and junit tests can both be executed. 

Please note that not all tests will pass in PublisherTest. There seem to be some incompatibilities that would need to be addressed there. Changing the return value to 1 in maxElementsFromPublisher will make those tests to be skipped. You might create a new branch for this until all tests can be fixed.
