### PR TITLE
Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 Troilus
 ======
+
+[![Build Status](https://travis-ci.org/1and1/Troilus.svg)](https://travis-ci.org/1and1/Troilus)
+
 **Troilus** is a high level Cassandra Java client on the top of the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver). 
 It supports synchronous programming and asynchronous programming.
 


### PR DESCRIPTION
Enables automatic travis builds upon commits. You still need to add the project in your travis-ci.org settings to have travis build and test it for you!

Java 7 (doesnt compile):
https://travis-ci.org/spodkowinski/Troilus/jobs/51241071
Java 8 (tck tests will fail as expected):
https://travis-ci.org/spodkowinski/Troilus/jobs/51241070
