### PR TITLE
Request inclusion of my upgrades and bugfixes to next release (0.17)

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,2 @@
+/org.eclipse.core.resources.prefs
+/org.eclipse.m2e.core.prefs

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,13 @@
 
+0.17 - Kritek Fork
+ * Pagination Support - ListRead.withPagingState(), ListReadQuery.toStatementAsync()
+ * Inheritance of @Field mappings for entities in BeanMapper
+ * Upgrade from Cassandra Datastax 2.2.0-rc2 driver to 3.0.0-beta1 driver
+ * Upgrade tests from Cassandra 2.x to Cassandra 3.0.0 (see pom.xml dependency and CassandraDB.java)
+ * bugfix: WriteQueryDataImpl.java toUpdateStatementAsync() no longer maps primary keys into Update SET
+ * bugfix: RecordImpl.PropertySourceAdapter rewrote read() and read(String name, Class<?> clazz1, Class<?> clazz2) to work with UDTValue collections.
+ * New test cases: PaginationTest.java, EntityInheritanceMappingTest.java, UDTValueMappingCollectionTests.java
+ 
 0.16
  * DaoImpl constructor supports keyspacename paramter instead dot-composed keyspace and tablename string
 

--- a/changes.txt
+++ b/changes.txt
@@ -4,6 +4,7 @@
  * Inheritance of @Field mappings for entities in BeanMapper
  * Upgrade from Cassandra Datastax 2.2.0-rc2 driver to 3.0.0-beta1 driver
  * Upgrade tests from Cassandra 2.x to Cassandra 3.0.0 (see pom.xml dependency and CassandraDB.java)
+ * LocalDateTime Support - Record.java interfaces and implementations
  * bugfix: WriteQueryDataImpl.java toUpdateStatementAsync() no longer maps primary keys into Update SET
  * bugfix: RecordImpl.PropertySourceAdapter rewrote read() and read(String name, Class<?> clazz1, Class<?> clazz2) to work with UDTValue collections.
  * New test cases: PaginationTest.java, EntityInheritanceMappingTest.java, UDTValueMappingCollectionTests.java

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,17 @@
 		<version>1.5.1</version>
 	</parent>
 
+	<!-- 
+	  This is the Kritek fork of Troilus .17-SNAPSHOT
+	  See changes.txt for what was added to Kritek fork.
+	  
+	  NOTE: To build in Eclipse IDE, just delete this Problems 'Marker', whenever it shows up:
+	  
+	  Description	Resource	Path	Location	Type
+	  ============================================================
+	  Plugin execution not covered by lifecycle configuration: org.jacoco:jacoco-maven-plugin:0.7.2.201409121644:prepare-agent (execution: default-prepare-agent, phase: initialize)	pom.xml	/troilus-core	line 5	Maven Project Build Lifecycle Mapping Problem
+	  
+	-->
 	<groupId>net.oneandone.troilus</groupId>
 	<artifactId>troilus-parent</artifactId>
 	<version>0.17-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	-->
 	<groupId>net.oneandone.troilus</groupId>
 	<artifactId>troilus-parent</artifactId>
-	<version>0.17-SNAPSHOT</version>
+	<version>0.17-RELEASE</version>
 	<packaging>pom</packaging>
 
         <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
         <properties>
                 <!-- later versions -->
                 <surefire.version>2.15</surefire.version>
+                <reactivestreams.version>1.0.0</reactivestreams.version>
+                <cassandra.driver.core.version>3.0.0-beta1</cassandra.driver.core.version>
+                <cassandra.version>3.0.0</cassandra.version>
         </properties>
 
 	<name>troilus-parent multimodule</name>
@@ -36,13 +39,13 @@
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
 			<!--<version>2.2.0-rc2</version>-->
-			<version>2.1.7.1</version>
+			<version>${cassandra.driver.core.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.reactivestreams</groupId>
 			<artifactId>reactive-streams</artifactId>
-			<version>1.0.0.final</version>
+			<version>${reactivestreams.version}</version>
 		</dependency>
 
 		<!-- use the same log framework the underlying cassandra driver is using -->
@@ -64,7 +67,7 @@
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>cassandra-all</artifactId>
-			<version>2.2.0</version>
+			<version>${cassandra.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/troilus-core-java7/pom.xml
+++ b/troilus-core-java7/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.oneandone.troilus</groupId>
 		<artifactId>troilus-parent</artifactId>
-		<version>0.17-SNAPSHOT</version>
+		<version>0.17-RELEASE</version>
 	</parent>
 	<artifactId>troilus-core-java7</artifactId>
 	<packaging>jar</packaging>

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/DBSession.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/DBSession.java
@@ -41,6 +41,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * DBSession
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API changes - getProtocolVersion()
  */
 public class DBSession  {
     private static final Logger LOG = LoggerFactory.getLogger(DBSession.class);
@@ -96,7 +99,9 @@ public class DBSession  {
      */
     ProtocolVersion getProtocolVersion() {
         //return getSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
-        return getSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum();
+        //return getSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum();
+        
+        return getSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
     }
     
  

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
@@ -18,6 +18,7 @@ package net.oneandone.troilus;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import net.oneandone.troilus.java7.FetchingIterator;
 import net.oneandone.troilus.java7.ListRead;
@@ -30,6 +31,7 @@ import net.oneandone.troilus.java7.interceptor.ReadQueryResponseInterceptor;
 
 import org.reactivestreams.Publisher;
 
+import com.datastax.driver.core.PagingState;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Clause;
@@ -52,6 +54,8 @@ import com.google.common.util.concurrent.ListenableFuture;
  * 
  * @author Jason Westra - edited original
  * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
+ * 12-13-2015: pagination APIs - withPagingState(), added toStatementAsync() - to set fetchSize & pagingState properly
+ * 				modified executeAsync() - calls toStatementAsync() to set up pagination properties, if needed
  *
  */
 class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWithUnit<ResultList<Record>, Record> {
@@ -154,6 +158,11 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
     }
     
     @Override
+    public ListReadQuery withPagingState(PagingState pagingState) {
+        return newQuery(data.pagingState(pagingState));
+    }
+    
+    @Override
     public CountReadQuery count() {
         return new CountReadQuery(getContext(), new CountReadQueryData(data.getTablename())
                                                                         .whereConditions(data.getWhereConditions())
@@ -197,8 +206,12 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
 
     
     private ListenableFuture<ResultList<Record>> executeAsync(final ReadQueryData queryData, DBSession dbSession) {
-        // perform query
-        ListenableFuture<ResultSet> resultSetFuture = performAsync(dbSession, ReadQueryDataImpl.toStatementAsync(queryData, getUDTValueMapper(), dbSession));        
+        // 12-11-2015: jwestra - pagination support. Calls toStatementAsync() to perform
+    	// extra post-processing on the Statement to do pagination correctly
+    	// perform query
+    	ListenableFuture<ResultSet> resultSetFuture = performAsync(dbSession, toStatementAsync(queryData, getUDTValueMapper(), dbSession));
+    	
+        //ListenableFuture<ResultSet> resultSetFuture = performAsync(dbSession, ReadQueryDataImpl.toStatementAsync(queryData, getUDTValueMapper(), dbSession));        
         
         // result set to record list mapper
         Function<ResultSet, ResultList<Record>> resultSetToRecordList = new Function<ResultSet, ResultList<Record>>() {
@@ -254,6 +267,44 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
         return recordFuture;
     }
     
+    /**
+     * 12-11-2015: jwestra
+     * 
+     * Prepares the Statement for Pagination, if fetchSize is set. Otherwise, it simply  
+     * returns ReadQueryDataImpl.toStatementAsync(data, udtValueMapper, dbSession)
+     * as in the original code did in executeAsync().
+     * 
+     * @param queryData
+     * @param udtValueMapper
+     * @param dbSession
+     * 
+     * @return ListenableFuture<Statement>
+     */
+    private ListenableFuture<Statement> toStatementAsync(final ReadQueryData queryData, UDTValueMapper udtValueMapper, DBSession dbSession) {
+    	ListenableFuture<Statement> lfs = ReadQueryDataImpl.toStatementAsync(data, udtValueMapper, dbSession);
+    	
+    	Integer fetchSize = data.getFetchSize();
+    	if (fetchSize != null) {
+    		Statement statement = null;
+    		try {
+    			statement = lfs.get();
+    		} catch (InterruptedException | ExecutionException e) {
+    			throw new RuntimeException("Failed to get the Statement from ListenableFuture<Statement>", e);
+    		}
+    		
+			// The FetchSize is lost somehow when ReadQueryData.toStatementAsync() is invoked.
+    		// In the debugger, it was always zero.  So, it is reset here directly on the Statement
+			// This sets the fetchsize specifically on the Statement before executing.
+			statement.setFetchSize(fetchSize);
+			
+			// The PagingState is not set during ReadQueryData.toStatementAsync() because
+			// the driver compares the Select (a RegularStatement) to the previous PagingState's
+			// BoundStatement and fails the hash() check with a PagingStateException.
+			// So, like the fetch size, the PagingState must be done here.
+			statement.setPagingState(data.getPagingState());
+		}
+    	return lfs;
+    }
     
     /**
      * The entity list read implementation
@@ -323,6 +374,14 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
             ListenableFuture<ResultList<E>> recordsFuture = executeAsync();
             return new ResultListPublisher<>(recordsFuture);
         }
+
+		@Override
+		public ListEntityReadQuery<E> withPagingState(
+				PagingState pagingState) {
+			return query.withPagingState(pagingState).asEntity(clazz);
+		}
+
+
     }
     
     
@@ -604,6 +663,11 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
             
             return new ResultListPublisher<>(Futures.transform(countFuture, toListFunction));
         }
+
+		@Override
+		public ListRead<Count, Count> withPagingState(PagingState pagingState) {
+			throw new IllegalArgumentException("Count readers cannot be configured with paging state.");
+		}
     }  
 }
     

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/ListReadQuery.java
@@ -17,7 +17,6 @@ package net.oneandone.troilus;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
-
 import java.util.List;
 
 import net.oneandone.troilus.java7.FetchingIterator;
@@ -50,6 +49,9 @@ import com.google.common.util.concurrent.ListenableFuture;
  
 /**
  * The list read query implementation
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
  *
  */
 class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWithUnit<ResultList<Record>, Record> {
@@ -371,7 +373,7 @@ class ListReadQuery extends AbstractQuery<ListReadQuery> implements ListReadWith
                 }
                 
                 @Override
-                public ListenableFuture<Void> fetchMoreResultsAsync() {
+                public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
                     return recordIt.fetchMoreResultsAsync();
                 }
             };

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/MetadataCatalog.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/MetadataCatalog.java
@@ -16,7 +16,9 @@
 package net.oneandone.troilus;
 
 
+import java.util.List;
 import java.util.Set;
+
 
 
 
@@ -35,7 +37,11 @@ import com.google.common.collect.Sets;
  * MetadataCatalog including database metadata 
  * 
  * @author grro
- *
+ * 
+ * @author Jason Westra - edited original
+ * 12-13-2015: isPrimaryKey() - used to generate Update Statement properly
+ * @see WriteQueryDataImpl.toUpdateStatementAsync()
+ * 
  */
 class MetadataCatalog  {
 
@@ -77,7 +83,17 @@ class MetadataCatalog  {
         return userTypeCache.get(tablename, usertypeName);
     }
     
-    
+    /**
+     * Whether or not this column is part of the primary key
+     * @param tablename
+     * @param columnName
+     * @return true if pk, false otherwise
+     */
+    public boolean isPrimaryKey(Tablename tablename, String columnName) {
+    	List<ColumnMetadata> primaryKeys = tableMetadataCache.getMetadata(tablename).tableMetadata.getPrimaryKey();
+    	ColumnMetadata columnMetadata = getColumnMetadata(tablename, columnName);
+    	return primaryKeys.contains(columnMetadata);
+    }
     
 
     private static final class TableMetadataCache {

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/RecordImpl.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/RecordImpl.java
@@ -20,6 +20,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -37,7 +40,6 @@ import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.ColumnDefinitions.Definition;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ExecutionInfo;
-import com.datastax.driver.core.LocalDate;
 import com.datastax.driver.core.QueryTrace.Event;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TupleValue;
@@ -58,7 +60,7 @@ import com.google.common.collect.ImmutableSet;
  * Completely re-wrote PropertySourceAdapter's read() and 
  *       read(String name, Class<?> clazz1, Class<?> clazz2) to work with UDTValue collections.
  *       This is verified in UDTValueMappingCollectionTests.java
- * 
+ * 12-14-2015: getTime() - no longer returns -1.  Calls row.getTime(name), added getLocalDateTime() 
  */
 class RecordImpl implements Record {
     
@@ -193,8 +195,7 @@ class RecordImpl implements Record {
     
     @Override
     public long getTime(String name) {
-        //return row.getTime(name);
-        return -1;
+    	return row.getTime(name);
     }
     
     @Override
@@ -221,8 +222,14 @@ class RecordImpl implements Record {
     public Date getDate(String name) {
         //return new Date(row.getDate(name).getTime());
         // jwestra: 3.x API change
-        LocalDate ld = row.getDate(name);
-    	return new Date(ld.getMillisSinceEpoch());
+    	return row.getTimestamp(name);
+    }
+    
+    @Override
+    public LocalDateTime getLocalDateTime(String name) {
+    	long timestamp = row.getTimestamp(name).getTime();
+    	Instant instant = Instant.ofEpochMilli(timestamp);
+		return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
 
     @Override

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/RecordListImpl.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/RecordListImpl.java
@@ -29,7 +29,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: ListenableFuture<Void> to ListenableFuture<ResultSet>
+ *
+ */
 class RecordListImpl implements ResultList<Record> {
     private final Context ctx;
     private final ReadQueryData queryData;
@@ -80,7 +85,7 @@ class RecordListImpl implements ResultList<Record> {
            }
            
            @Override
-           public ListenableFuture<Void> fetchMoreResultsAsync() {
+           public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
                return rs.fetchMoreResults();
            }
            

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/ResultListPublisher.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/ResultListPublisher.java
@@ -17,15 +17,13 @@ package net.oneandone.troilus;
 
 import java.util.concurrent.ExecutionException;
 
-
-
-
 import net.oneandone.troilus.java7.FetchingIterator;
 import net.oneandone.troilus.java7.ResultList;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import com.datastax.driver.core.ResultSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -36,6 +34,9 @@ import com.google.common.util.concurrent.MoreExecutors;
  * ResultList-based publisher
  *
  * @param <R> the element type
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
  */
 class ResultListPublisher<R> implements Publisher<R> {
     
@@ -153,7 +154,7 @@ class ResultListPublisher<R> implements Publisher<R> {
         }
         
         @Override
-        public ListenableFuture<Void> fetchMoreResultsAsync() {
+        public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
             return Futures.immediateFuture(null);
         }
         

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/ResultListSubscription.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/ResultListSubscription.java
@@ -29,6 +29,7 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.datastax.driver.core.ResultSet;
 import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -38,6 +39,9 @@ import com.google.common.util.concurrent.ListenableFuture;
  * ResultListSubscription
  * 
  * @param <T> the element type
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: ListenableFuture<Void> to ListenableFuture<ResultSet>
  */
 class ResultListSubscription<T> implements Subscription {
     
@@ -182,7 +186,8 @@ class ResultListSubscription<T> implements Subscription {
                 synchronized (dbQueryLock) {
                     // submit an async database query (if not already running) 
                     if (runningDatabaseQuery == null) {
-                        ListenableFuture<Void> future = iterator.fetchMoreResultsAsync();
+                    	// 3.x API change
+                        ListenableFuture<ResultSet> future = iterator.fetchMoreResultsAsync();
                         
                         Runnable databaseRequest = new Runnable() {
                                                             @Override

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/SingleEntryResultListAdapter.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/SingleEntryResultListAdapter.java
@@ -23,11 +23,18 @@ import net.oneandone.troilus.java7.ResultList;
 import net.oneandone.troilus.java7.interceptor.ResultListAdapter;
 
 import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.ResultSet;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
+ *
+ * @param <T>
+ */
 class SingleEntryResultListAdapter<T extends Result> extends ResultListAdapter<T> {
 
     public SingleEntryResultListAdapter(T element) {
@@ -103,7 +110,7 @@ class SingleEntryResultListAdapter<T extends Result> extends ResultListAdapter<T
             }
             
             @Override
-            public ListenableFuture<Void> fetchMoreResultsAsync() {
+            public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
                 return Futures.immediateFuture(null);
             }
         }

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/SingleReadQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/SingleReadQuery.java
@@ -18,10 +18,6 @@ package net.oneandone.troilus;
 import java.util.Iterator;
 import java.util.List;
 
-
-
-import org.reactivestreams.Publisher;
-
 import net.oneandone.troilus.java7.FetchingIterator;
 import net.oneandone.troilus.java7.Record;
 import net.oneandone.troilus.java7.ResultList;
@@ -30,6 +26,9 @@ import net.oneandone.troilus.java7.SingleReadWithUnit;
 import net.oneandone.troilus.java7.interceptor.ReadQueryData;
 import net.oneandone.troilus.java7.interceptor.ResultListAdapter;
 
+import org.reactivestreams.Publisher;
+
+import com.datastax.driver.core.ResultSet;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,6 +41,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * Read query implementation
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
  */
 class SingleReadQuery extends AbstractQuery<SingleReadQuery> implements SingleReadWithUnit<Record, Record> {
 
@@ -286,7 +288,7 @@ class SingleReadQuery extends AbstractQuery<SingleReadQuery> implements SingleRe
             }
             
             @Override
-            public ListenableFuture<Void> fetchMoreResultsAsync() {
+            public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
                 return iterator.fetchMoreResultsAsync();
             }
             

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/FetchingIterator.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/FetchingIterator.java
@@ -49,5 +49,6 @@ public interface FetchingIterator<E> extends Iterator<E> {
      *         will be thrown (you should thus call isFullyFetched() to know if calling this method can be of any use).
      */
     ListenableFuture<ResultSet> fetchMoreResultsAsync();
+    //ListenableFuture<Void> fetchMoreResultsAsync();
 }
 

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/FetchingIterator.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/FetchingIterator.java
@@ -17,6 +17,7 @@ package net.oneandone.troilus.java7;
 
 import java.util.Iterator;
 
+import com.datastax.driver.core.ResultSet;
 import com.google.common.util.concurrent.ListenableFuture;
 
 
@@ -25,6 +26,9 @@ import com.google.common.util.concurrent.ListenableFuture;
  * Iterator which supports fetching methods
  * 
  * @param <E> the element type
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
  */
 public interface FetchingIterator<E> extends Iterator<E> {
 
@@ -44,6 +48,6 @@ public interface FetchingIterator<E> extends Iterator<E> {
      *         then the returned future will return immediately but not particular error 
      *         will be thrown (you should thus call isFullyFetched() to know if calling this method can be of any use).
      */
-    ListenableFuture<Void> fetchMoreResultsAsync();
+    ListenableFuture<ResultSet> fetchMoreResultsAsync();
 }
 

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/ListRead.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/ListRead.java
@@ -15,12 +15,17 @@
  */
 package net.oneandone.troilus.java7;
 
+import com.datastax.driver.core.PagingState;
+
 
 
 /**
  * List read query
  *
  * @param <T> the result type
+ *
+ * @author Jason Westra - edited original
+ * 12-13-2015: pagination APIs - withPagingState()
  */
 public interface ListRead<T, R> extends SingleRead<T, R> {
 
@@ -46,4 +51,9 @@ public interface ListRead<T, R> extends SingleRead<T, R> {
      * @return a cloned query instance which allows filtering
      */
     ListRead<T, R> withAllowFiltering();
+    
+    /**
+     * @return a cloned query instance which allows paging
+     */
+    ListRead<T, R> withPagingState(PagingState pagingState);
 }

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Record.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Record.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
@@ -38,6 +39,8 @@ import com.google.common.collect.ImmutableSet;
  * record result
  *
  * @author grro
+ * @author Jason Westra - edited original
+ * 12-14-2015: added getLocalDateTime()
  */
 public interface Record extends Result {
    
@@ -110,6 +113,11 @@ public interface Record extends Result {
      */
     long getTime(String name);
 
+    /**
+     * @param name
+     * @return LocalDateTime
+     */
+    LocalDateTime getLocalDateTime(String name);
     
     /**
      * @param name the column name 

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/interceptor/ReadQueryData.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/interceptor/ReadQueryData.java
@@ -18,6 +18,7 @@ package net.oneandone.troilus.java7.interceptor;
 
 import net.oneandone.troilus.Tablename;
 
+import com.datastax.driver.core.PagingState;
 import com.datastax.driver.core.querybuilder.Clause;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -28,6 +29,9 @@ import com.google.common.collect.ImmutableSet;
  
 /**
  * list read query data 
+ * 
+ * @author Jason Westra - edited original
+ * 12-13-2015: pagination APIs - getPagingState(), pagingState()
  */
 public interface ReadQueryData {
     
@@ -115,4 +119,17 @@ public interface ReadQueryData {
      * @return the distinct flag
      */
     Boolean getDistinct();
+    
+    /**
+     * @return paging state or null, if none
+     * @return
+     */
+    PagingState getPagingState();
+    
+    /** Sets paging state
+     * 
+     * @param pagingState
+     * @return
+     */
+    ReadQueryData pagingState(PagingState pagingState);
 }

--- a/troilus-core/pom.xml
+++ b/troilus-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.oneandone.troilus</groupId>
 		<artifactId>troilus-parent</artifactId>
-		<version>0.17-SNAPSHOT</version>
+		<version>0.17-RELEASE</version>
 	</parent>
 	<artifactId>troilus-core</artifactId>
 	<packaging>jar</packaging>
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>net.oneandone.troilus</groupId>
 			<artifactId>troilus-core-java7</artifactId>
-			<version>0.17-SNAPSHOT</version>
+			<version>0.17-RELEASE</version>
 		</dependency>
 
 

--- a/troilus-core/pom.xml
+++ b/troilus-core/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.reactivestreams</groupId>
 			<artifactId>reactive-streams-tck</artifactId>
-			<version>1.0.0.final</version>
+			<version>${reactivestreams.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/troilus-core/src/main/java/net/oneandone/troilus/DaoImpl.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/DaoImpl.java
@@ -18,29 +18,20 @@ package net.oneandone.troilus;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import net.oneandone.troilus.Context;
-import net.oneandone.troilus.DeleteQuery;
-import net.oneandone.troilus.DeleteQueryDataImpl;
-import net.oneandone.troilus.ListReadQuery;
-import net.oneandone.troilus.ReadQueryDataImpl;
-import net.oneandone.troilus.ColumnName;
-import net.oneandone.troilus.SingleReadQuery;
-import net.oneandone.troilus.UpdateQuery;
-import net.oneandone.troilus.WriteQueryDataImpl;
 import net.oneandone.troilus.interceptor.CascadeOnDeleteInterceptor;
 import net.oneandone.troilus.interceptor.CascadeOnWriteInterceptor;
 import net.oneandone.troilus.interceptor.DeleteQueryData;
 import net.oneandone.troilus.interceptor.DeleteQueryRequestInterceptor;
+import net.oneandone.troilus.interceptor.QueryInterceptor;
 import net.oneandone.troilus.interceptor.ReadQueryData;
 import net.oneandone.troilus.interceptor.ReadQueryRequestInterceptor;
 import net.oneandone.troilus.interceptor.ReadQueryResponseInterceptor;
-import net.oneandone.troilus.interceptor.QueryInterceptor;
 import net.oneandone.troilus.interceptor.WriteQueryData;
 import net.oneandone.troilus.interceptor.WriteQueryRequestInterceptor;
 import net.oneandone.troilus.java7.Batchable;
@@ -48,11 +39,12 @@ import net.oneandone.troilus.java7.Batchable;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.querybuilder.Clause;
-import com.datastax.driver.core.ConsistencyLevel;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -64,6 +56,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * DaoImpl
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - CompletableFuture<Void> to CompletableFuture<ResultSet>
  */
 public class DaoImpl implements Dao {
     
@@ -570,7 +565,7 @@ public class DaoImpl implements Dao {
                 }
                 
                 @Override
-                public CompletableFuture<Void> fetchMoreResultsAsync() {
+                public CompletableFuture<ResultSet> fetchMoreResultsAsync() {
                     return CompletableFutures.toCompletableFuture(iterator.fetchMoreResultsAsync());
                 }
                 
@@ -627,7 +622,7 @@ public class DaoImpl implements Dao {
                         }
                         
                         @Override
-                        public ListenableFuture<Void> fetchMoreResultsAsync() {
+                        public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
                             return CompletableFutures.toListenableFuture(iterator.fetchMoreResultsAsync());
                         }
                         
@@ -709,7 +704,7 @@ public class DaoImpl implements Dao {
                }
                
                @Override
-               public CompletableFuture<Void> fetchMoreResultsAsync() {
+               public CompletableFuture<ResultSet> fetchMoreResultsAsync() {
                    return CompletableFutures.toCompletableFuture(recordIt.fetchMoreResultsAsync());
                }
            };

--- a/troilus-core/src/main/java/net/oneandone/troilus/FetchingIterator.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/FetchingIterator.java
@@ -18,12 +18,17 @@ package net.oneandone.troilus;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
+import com.datastax.driver.core.ResultSet;
+
 
 
 /**
  * Iterator which supports fetching methods
  * 
  * @param <E> the element type
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - CompletableFuture<Void> to CompletableFuture<ResultSet>
  */
 public interface FetchingIterator<E> extends Iterator<E> {
 
@@ -44,6 +49,6 @@ public interface FetchingIterator<E> extends Iterator<E> {
      *         then the returned future will return immediately but not particular error 
      *         will be thrown (you should thus call isFullyFetched() to know if calling this method can be of any use).
      */
-    CompletableFuture<Void> fetchMoreResultsAsync();
+    CompletableFuture<ResultSet> fetchMoreResultsAsync();
 }
 

--- a/troilus-core/src/main/java/net/oneandone/troilus/ListRead.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/ListRead.java
@@ -15,6 +15,8 @@
  */
 package net.oneandone.troilus;
 
+import com.datastax.driver.core.PagingState;
+
 
 
 
@@ -22,6 +24,9 @@ package net.oneandone.troilus;
  * List read query
  *
  * @param <T> the result type
+ * 
+ * @author Jason Westra - edited original
+ * 12-13-2015: pagination APIs - withPagingState()
  */
 public interface ListRead<T, R> extends SingleRead<T, R> {
     
@@ -47,4 +52,11 @@ public interface ListRead<T, R> extends SingleRead<T, R> {
      * @return a cloned query instance which allows filtering
      */
     ListRead<T, R> withAllowFiltering();
+    
+    /**
+	 * 
+	 * @param pagingState  paging state to set on driver Statement, or null, if none
+	 * @return a cloned query instance with paging state set
+	 */
+	ListRead<T, R> withPagingState(PagingState pagingState);
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/ListReadQueryAdapter.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/ListReadQueryAdapter.java
@@ -20,7 +20,11 @@ import java.util.concurrent.CompletableFuture;
 
 
 
+
+
 import org.reactivestreams.Publisher;
+
+import com.datastax.driver.core.PagingState;
 
 import net.oneandone.troilus.AbstractQuery;
 import net.oneandone.troilus.Context;
@@ -35,6 +39,9 @@ import net.oneandone.troilus.ListReadQuery.ListEntityReadQuery;
 
 /**
  * Java8 adapter of a ListReadQuery
+ * 
+ * @author Jason Westra - edited original
+ * 12-13-2015: pagination APIs - withPagingState()
  */
 class ListReadQueryAdapter extends AbstractQuery<ListReadQueryAdapter> implements ListReadWithUnit<ResultList<Record>, Record> {
 
@@ -122,6 +129,12 @@ class ListReadQueryAdapter extends AbstractQuery<ListReadQueryAdapter> implement
         return newQuery(query.withDistinct());
     }
     
+	@Override
+	public ListRead<ResultList<Record>, Record> withPagingState(
+			PagingState pagingState) {
+		return newQuery(query.withPagingState(pagingState));
+	}  
+	
     @Override
     public ListRead<Count, Count> count() {
         return new CountReadQueryAdapter(getContext(), query.count());
@@ -208,6 +221,12 @@ class ListReadQueryAdapter extends AbstractQuery<ListReadQueryAdapter> implement
         public Publisher<E> executeRx() {
             return query.executeRx();
         }
+        
+        @Override
+    	public ListRead<ResultList<E>, E> withPagingState(
+    			PagingState pagingState) {
+        	return new ListEntityReadQueryAdapter<>(getContext(), query.withPagingState(pagingState));
+        }  
     }
     
     
@@ -268,6 +287,11 @@ class ListReadQueryAdapter extends AbstractQuery<ListReadQueryAdapter> implement
         @Override
         public CompletableFuture<Count> executeAsync() {
             return CompletableFutures.toCompletableFuture(query.executeAsync());
-        }        
+        }    
+        
+        @Override
+		public ListRead<Count, Count> withPagingState(PagingState pagingState) {
+			throw new IllegalArgumentException("Count readers cannot be configured with paging state.");
+		}      
     }  
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/Record.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/Record.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import net.oneandone.troilus.ColumnName;
@@ -39,6 +40,8 @@ import com.google.common.collect.ImmutableSet;
  * record result
  *
  * @author grro
+ * @author Jason Westra - edited original
+ * 12-14-2015: added getLocalDateTime()
  */
 public interface Record extends Result {
    
@@ -109,6 +112,12 @@ public interface Record extends Result {
      */
     long getTime(String name);
   
+    /**
+     * @param name
+     * @return LocalDateTime
+     */
+    LocalDateTime getLocalDateTime(String name);
+    
     /**
      * @param name the column name 
      * @return the value of column name as a decimal. If the value is NULL, null is returned

--- a/troilus-core/src/main/java/net/oneandone/troilus/RecordAdapter.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/RecordAdapter.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
@@ -42,6 +43,9 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * Java8 adapter of a Record
+ * 
+ * @author Jason Westra - edited original
+ * 12-14-2015: added getLocalDateTime()
  */
 class RecordAdapter implements Record {
     
@@ -128,6 +132,11 @@ class RecordAdapter implements Record {
     @Override
     public long getTime(String name) {
         return record.getTime(name);
+    }
+    
+    @Override
+    public LocalDateTime getLocalDateTime(String name) {
+    	return record.getLocalDateTime(name);
     }
      
     @Override
@@ -366,6 +375,11 @@ class RecordAdapter implements Record {
             public boolean getBool(String name) {
                 return record.getBool(name);
             }
+
+			@Override
+			public LocalDateTime getLocalDateTime(String name) {
+				return record.getLocalDateTime(name);
+			}
         };
     }
 }

--- a/troilus-core/src/test/java/net/oneandone/troilus/CassandraDB.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/CassandraDB.java
@@ -45,7 +45,12 @@ import com.google.common.io.Files;
 import com.google.common.io.Resources;
 
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change
+ *
+ */
 public class CassandraDB {
 
     private static final String CASSANDRA_YAML_FILE = "cassandra.yaml";
@@ -214,7 +219,9 @@ public class CassandraDB {
             long maxWaiting = System.currentTimeMillis() + 10000;
             
             while (System.currentTimeMillis() < maxWaiting) {
-                if (cassandraDaemon.nativeServer.isRunning()) {
+            	// jwestra: 3.x API change
+            	if (cassandraDaemon.isNativeTransportRunning()) {
+                //if (cassandraDaemon.nativeServer.isRunning()) {
                     init();
                     return;
                 }
@@ -260,7 +267,10 @@ public class CassandraDB {
     private static void shutdown() {
         try {
             cassandraDaemon.thriftServer.stop();
-            cassandraDaemon.nativeServer.stop();
+            
+            // jwestra: 3.x API change
+            cassandraDaemon.stop();
+            //cassandraDaemon.nativeServer.stop();
         } catch (Throwable t) {
             t.printStackTrace();
         }
@@ -315,10 +325,16 @@ public class CassandraDB {
             cassandraConfiguration.put("commitlog_directory", new File(cassandraDir, "commitlog").getAbsolutePath());
             cassandraConfiguration.put("saved_caches_directory", new File(cassandraDir, "saved_caches").getAbsolutePath());
             
+            // jwestra: 3.x API change: resolve error on start of 'hints_directory' is missing
+            cassandraConfiguration.put("hints_directory", new File(cassandraDir, "hints_directory").getAbsolutePath());
+                      
             cassandraConfigurationOutput =
               new OutputStreamWriter(new FileOutputStream(cassandraDirName + File.separator + CASSANDRA_YAML_FILE), Charsets.UTF_8);
 
-            
+            // jwestra: 3.x API change: resolve error on start of -Dcassandra.storage_dir is not set
+            String storageDir = new File(cassandraDir, "storageDir").getAbsolutePath();
+            System.setProperty("cassandra.storage_dir", storageDir);
+            // end: 3.x API change
             
             yaml.dump(cassandraConfiguration, cassandraConfigurationOutput);
             

--- a/troilus-core/src/test/java/net/oneandone/troilus/SimpleResultList.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/SimpleResultList.java
@@ -16,7 +16,6 @@
 package net.oneandone.troilus;
 
 import java.math.BigDecimal;
-
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -31,6 +30,7 @@ import net.oneandone.troilus.java7.FetchingIterator;
 import org.testng.collections.Lists;
 
 import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.TupleValue;
 import com.datastax.driver.core.UDTValue;
 import com.google.common.collect.ImmutableList;
@@ -41,7 +41,12 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
+ *
+ */
 public class SimpleResultList implements net.oneandone.troilus.java7.ResultList<Record> {
     private final long elements;
     private final int fetchDelayMillis;
@@ -128,9 +133,9 @@ public class SimpleResultList implements net.oneandone.troilus.java7.ResultList<
         }
         
         @Override
-        public ListenableFuture<Void> fetchMoreResultsAsync() {
+        public ListenableFuture<ResultSet> fetchMoreResultsAsync() {
 
-            return new AbstractFuture<Void>() {
+            return new AbstractFuture<ResultSet>() {
                 
                 {
                     new Thread() {

--- a/troilus-core/src/test/java/net/oneandone/troilus/SimpleResultList.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/SimpleResultList.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -45,7 +46,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  * 
  * @author Jason Westra - edited original
  * 12-12-2015: 3.x API change - ListenableFuture<Void> to ListenableFuture<ResultSet>
- *
+ * 12-14-2015: added getLocalDateTime()
  */
 public class SimpleResultList implements net.oneandone.troilus.java7.ResultList<Record> {
     private final long elements;
@@ -370,6 +371,12 @@ public class SimpleResultList implements net.oneandone.troilus.java7.ResultList<
                         // TODO Auto-generated method stub
                         return false;
                     }
+
+					@Override
+					public LocalDateTime getLocalDateTime(String name) {
+						// TODO Auto-generated method stub
+						return null;
+					}
                 };
             }   
         }

--- a/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationInvites.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationInvites.java
@@ -1,0 +1,18 @@
+/**
+ * 
+ */
+package net.oneandone.troilus.api;
+
+/**
+ * @author Jason Westra
+ *
+ */
+public interface PaginationInvites {
+
+	public static final String DDL = "com/unitedinternet/troilus/example/invites.ddl";
+	
+	public static final String TABLE_NAME = "invites_by_group";
+	
+	public static final String INVITE_DATE = "invite_date";
+	
+}

--- a/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
@@ -1,0 +1,315 @@
+/**
+ * 
+ */
+package net.oneandone.troilus.api;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Iterator;
+
+import junit.framework.TestCase;
+import net.oneandone.troilus.CassandraDB;
+import net.oneandone.troilus.Count;
+import net.oneandone.troilus.Dao;
+import net.oneandone.troilus.DaoImpl;
+import net.oneandone.troilus.Field;
+import net.oneandone.troilus.ListRead;
+import net.oneandone.troilus.ListReadWithUnit;
+import net.oneandone.troilus.Record;
+import net.oneandone.troilus.ResultList;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+import com.datastax.driver.core.PagingState;
+import com.datastax.driver.core.Session;
+
+/**
+ * Checks pagination API, verifying paging works and sorts
+ * records properly
+ * 
+ * Pagination requires:
+ * - fetchSize  (size of each page)
+ * - pagingState
+ * 
+ * @author Jason Westra
+ *
+ */
+@RunWith(value=BlockJUnit4ClassRunner.class)
+public class PaginationTest extends TestCase implements PaginationInvites {
+
+	private static CassandraDB cassandra;
+	 
+	public static final String keyspace = "ks_"+System.currentTimeMillis();
+	
+	public static final String TABLE_NAME = "invites_by_group";
+	
+	private static int ROW_COUNT = 100;
+	
+		
+	@BeforeClass
+    public static void beforeClass() throws IOException {
+        cassandra = CassandraDB.newInstance();
+        dropKeyspace();
+		createKeyspace();
+		
+		cassandra.tryExecuteCqlFile(PaginationInvites.DDL);
+        loadInvites();
+	}
+        
+    @AfterClass
+    public static void afterClass() throws IOException {
+    	dropKeyspace();
+        cassandra.close();
+    }
+	
+    private static void createKeyspace() {
+    	cassandra.getSession().execute("CREATE KEYSPACE "+keyspace+" with replication={'class': 'SimpleStrategy', 'replication_factor' : 1};");
+		cassandra.executeCql("USE "+keyspace+";");
+	}
+
+	private static void dropKeyspace() {
+		try {
+			Session session = cassandra.getSession();
+			session.execute("DROP KEYSPACE "+keyspace+";");
+		} catch(Exception e) {}
+	}
+	
+	// Loads 100 invites, they should be .x seconds apart and an ordered fetch
+	// should being back the rows in order
+	private static void loadInvites() {
+		for (int i = 1; i <= ROW_COUNT; i++) {
+			cassandra.executeCql(
+					"INSERT INTO "+TABLE_NAME+
+					" (group_id, invite_date, email_address)"+
+					" VALUES ('group_1', toTimestamp(NOW()), 'a"+i+"@foo.com');");
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	@Test
+	public void testLoadInvites() {
+		Dao dao = new DaoImpl(cassandra.getSession(), TABLE_NAME);
+		ListReadWithUnit<ResultList<Record>, Record> listReadUnit = dao.readSequenceWithKey("group_id", "group_1");
+		Count count = listReadUnit.count().execute();
+		
+		assertEquals(ROW_COUNT, count.getCount());
+	}
+	
+	
+	@Test
+	public void testFetchInvitesAsList() {
+		Dao dao = new DaoImpl(cassandra.getSession(), TABLE_NAME);
+		ListReadWithUnit<ResultList<Record>, Record> listReadUnit = dao.readSequenceWithKey("group_id", "group_1");
+		ResultList<Record> resultList = listReadUnit.all().execute();
+		
+		Iterator<Record> i = resultList.iterator();
+		int numRecords = assertSortOrder(i);
+		assertEquals("Size should be "+ROW_COUNT, ROW_COUNT, numRecords);
+	}
+	
+	// Limit doesn't really do pagination,but this is a sanity check
+	// to see that limit is not broken by any pagination API changes
+	// and data comes back sorted as expectd
+	@Test
+	public void testFetchInvitesListWithLimit() {
+		int LIMIT = 30;
+		Dao dao = new DaoImpl(cassandra.getSession(), TABLE_NAME);
+		ListReadWithUnit<ResultList<Record>, Record> listReadUnit = dao.readSequenceWithKey("group_id", "group_1");
+		ListRead<ResultList<Record>, Record> listread = listReadUnit.all();
+		ResultList<Record> resultList = listread.withLimit(LIMIT).execute();
+		
+		Iterator<Record> i = resultList.iterator();
+		int numRecords = assertSortOrder(i);
+		
+		assertEquals("Fetched incorrect number of records", LIMIT, numRecords);
+	}
+	
+	@Test
+	public void testFetchInvitesPageOfRecords() {
+		PagingState pagingState = null;
+				
+		// page #, page size, # of expected results in the page
+		pagingState = fetchAndAssert(1, 30, 30, pagingState);
+		pagingState = fetchAndAssert(2, 30, 30, pagingState);
+		pagingState = fetchAndAssert(3, 30, 30, pagingState);
+		pagingState = fetchAndAssert(4, 30, 10, pagingState);
+		
+		// Last page results in empty paging state again
+		assertNull(pagingState);
+	}
+	
+	@Test
+	public void testFetchInvitesPageOfEntities() {
+		PagingState pagingState = null;
+				
+		// page #, page size, # of expected results in the page
+		pagingState = fetchEntityAndAssert(1, 30, 30, pagingState);
+		pagingState = fetchEntityAndAssert(2, 30, 30, pagingState);
+		pagingState = fetchEntityAndAssert(3, 30, 30, pagingState);
+		pagingState = fetchEntityAndAssert(4, 30, 10, pagingState);
+		
+		// Last page results in empty paging state again
+		assertNull(pagingState);
+	}
+	
+	
+	private PagingState fetchAndAssert(int pageNumber, int pageSize, int expectedSize, PagingState pagingState) {
+		Dao dao = new DaoImpl(cassandra.getSession(), TABLE_NAME);
+		
+		ListReadWithUnit<ResultList<Record>, Record> listReadUnit = dao.readSequenceWithKey("group_id", "group_1");
+				
+		// Pagination requires both: fetchSize and pagingState
+		ListRead<ResultList<Record>, Record> listRead = listReadUnit.all()
+				.withFetchSize(pageSize)
+				.withPagingState(pagingState);
+		
+		ResultList<Record> resultList = listRead.execute();
+		
+		Iterator<Record> i = resultList.iterator();
+			
+		int numRecords = assertSortOrder(i);
+		
+		assertEquals("Size should be "+expectedSize, expectedSize, numRecords);
+		
+		return resultList.getExecutionInfo().getPagingState();
+	}
+	
+	private PagingState fetchEntityAndAssert(int pageNumber, int pageSize, int expectedSize, PagingState pagingState) {
+		ResultList<InvitesByMonthAndInviteDate> resultList = 
+				new DaoImpl(cassandra.getSession(), TABLE_NAME)
+			.readSequenceWithKey("group_id", "group_1")
+			.asEntity(InvitesByMonthAndInviteDate.class)
+			.withFetchSize(pageSize)
+			.withPagingState(pagingState)
+			.execute();
+			
+		int numRecords = assertSortOrder(resultList);
+		
+		assertEquals("Size should be "+expectedSize, expectedSize, numRecords);
+		
+		return resultList.getExecutionInfo().getPagingState();
+	}
+	
+	/**
+	 * @param i
+	 * @return number of rows iterated over
+	 */
+	private int assertSortOrder(Iterator<Record> i) {
+		LocalDateTime previousInviteDate = null;
+		int cnt = 0;
+		while(i.hasNext()) {
+			Record record = i.next();
+			LocalDateTime inviteDate = convert(record.getValue(INVITE_DATE, Date.class));
+			if (previousInviteDate != null) {
+				if (previousInviteDate.isAfter(inviteDate)) {
+					fail("Fetched out of order of the invite date");
+				}
+			}
+			
+			previousInviteDate = inviteDate;
+			cnt++;
+		}
+		return cnt;
+	}
+	
+	/**
+	 * @param results
+	 * @return number of rows iterated over
+	 */
+	private int assertSortOrder(ResultList<InvitesByMonthAndInviteDate> results) {
+		Iterator<InvitesByMonthAndInviteDate> i = results.iterator();
+		LocalDateTime previousInviteDate = null;
+		int cnt = 0;
+		while(i.hasNext()) {
+			InvitesByMonthAndInviteDate invite = i.next();
+			
+			LocalDateTime inviteDate = convert(invite.getInviteDate());
+			if (previousInviteDate != null) {
+				if (previousInviteDate.isAfter(inviteDate)) {
+					fail("Fetched out of order of the invite date");
+				}
+			}
+			
+			previousInviteDate = inviteDate;
+			cnt++;
+		}
+		return cnt;
+	}
+	
+	public static class InvitesByMonthAndInviteDate {
+		
+		
+		@Field(name="group_id")
+		private String groupId;
+		
+		@Field(name="email_address")
+		private String emailAddress;
+		
+		@Field(name="invite_date")
+		private Date inviteDate;
+
+
+		/**
+		 * @return the groupId
+		 */
+		public String getGroupId() {
+			return groupId;
+		}
+
+		/**
+		 * @param groupId the groupId to set
+		 */
+		public void setGroupId(String groupId) {
+			this.groupId = groupId;
+		}
+		
+		/**
+		 * @return the emailAddress
+		 */
+		public String getEmailAddress() {
+			return emailAddress;
+		}
+
+		/**
+		 * @param emailAddress the emailAddress to set
+		 */
+		public void setEmailAddress(String emailAddress) {
+			this.emailAddress = emailAddress;
+		}
+
+		/**
+		 * @return the inviteDate
+		 */
+		public Date getInviteDate() {
+			return inviteDate;
+		}
+
+		/**
+		 * @param inviteDate the inviteDate to set
+		 */
+		public void setInviteDate(Date inviteDate) {
+			this.inviteDate = inviteDate;
+		}
+		
+	}
+	
+	
+	
+	private LocalDateTime convert(Date date) {
+		Instant instant = Instant.ofEpochMilli(date.getTime());
+		LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+		return ldt;
+	}
+
+}

--- a/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
@@ -39,6 +39,7 @@ import com.datastax.driver.core.Session;
  * - pagingState
  * 
  * @author Jason Westra
+ * 12-14-2015: Maps LocalDateTime field to Entity without need to convert(date)
  *
  */
 @RunWith(value=BlockJUnit4ClassRunner.class)
@@ -234,7 +235,7 @@ public class PaginationTest extends TestCase implements PaginationInvites {
 		while(i.hasNext()) {
 			InvitesByMonthAndInviteDate invite = i.next();
 			
-			LocalDateTime inviteDate = convert(invite.getInviteDate());
+			LocalDateTime inviteDate = invite.getInviteDate();
 			if (previousInviteDate != null) {
 				if (previousInviteDate.isAfter(inviteDate)) {
 					fail("Fetched out of order of the invite date");
@@ -257,7 +258,7 @@ public class PaginationTest extends TestCase implements PaginationInvites {
 		private String emailAddress;
 		
 		@Field(name="invite_date")
-		private Date inviteDate;
+		private LocalDateTime inviteDate;
 
 
 		/**
@@ -291,14 +292,14 @@ public class PaginationTest extends TestCase implements PaginationInvites {
 		/**
 		 * @return the inviteDate
 		 */
-		public Date getInviteDate() {
+		public LocalDateTime getInviteDate() {
 			return inviteDate;
 		}
 
 		/**
 		 * @param inviteDate the inviteDate to set
 		 */
-		public void setInviteDate(Date inviteDate) {
+		public void setInviteDate(LocalDateTime inviteDate) {
 			this.inviteDate = inviteDate;
 		}
 		

--- a/troilus-core/src/test/java/net/oneandone/troilus/api/SessionReplacedTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/api/SessionReplacedTest.java
@@ -18,7 +18,9 @@ package net.oneandone.troilus.api;
 
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,7 +55,12 @@ import com.datastax.driver.core.Statement;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: prepareAsync(), initAsync() added to make it compile, but not implemented
+ *
+ */
 public class SessionReplacedTest {
     
     private static CassandraDB cassandra;
@@ -99,7 +106,7 @@ public class SessionReplacedTest {
                                  ImmutableSet.of("1", "2", "3", "122", "123", "124", "322", "333"),
                                  Optional.of(ClassifierEnum.FIVE), 
                                  Optional.of("Superb hotel housed in a heritage building - exudes old world charm"),
-                                 new Address("Erzsébet körút 43", "Budapest", "1073"),
+                                 new Address("Erzsï¿½bet kï¿½rï¿½t 43", "Budapest", "1073"),
                                  Optional.empty());
                
         hotelsDao.writeEntity(entity)
@@ -250,6 +257,21 @@ public class SessionReplacedTest {
         protected ListenableFuture<PreparedStatement> prepareAsync(String query, Map<String, ByteBuffer> customPayload) {
             return null;
         }*/
+        
+        // 3.x API change
+        @Override
+		public ListenableFuture<Session> initAsync() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+        // 3.x API change
+		@Override
+		protected ListenableFuture<PreparedStatement> prepareAsync(
+				String query, Map<String, ByteBuffer> customPayload) {
+			// TODO Auto-generated method stub
+			return null;
+		}
     }
 }
 

--- a/troilus-core/src/test/java/net/oneandone/troilus/cascade/CascadingTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/cascade/CascadingTest.java
@@ -18,7 +18,6 @@ package net.oneandone.troilus.cascade;
 
 
 import java.io.IOException;
-
 import java.util.Optional;
 
 
@@ -42,19 +41,30 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.collect.ImmutableSet;
 
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API changes
+ *
+ */
 public class CascadingTest {
 
     private static CassandraDB cassandra;
     
+    // 3.x API change
+    private ProtocolVersion protocolVersion = ProtocolVersion.NEWEST_SUPPORTED;
+    // 3.x API change
+    private CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
     
     @BeforeClass
     public static void beforeClass() throws IOException {
@@ -90,7 +100,8 @@ public class CascadingTest {
         
         //////////////////////////////////////
         // insert 
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+       // TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                        .value(KeyByAccountColumns.KEY, key)
                        .addSetValue(KeyByAccountColumns.EMAIL_IDX, idxType.newValue(email, time))
@@ -159,7 +170,9 @@ public class CascadingTest {
         
         //////////////////////////////////////
         // insert 
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        // 3.x API change
+        //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                        .value(KeyByAccountColumns.KEY, key)
                        .value(KeyByAccountColumns.EMAIL_IDX, ImmutableSet.of(idxType.newValue(email, time)))
@@ -283,7 +296,9 @@ public class CascadingTest {
         
         //////////////////////////////////////
         // insert
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        // 3.x API change
+        //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         try {
             keyByAccountDao.writeWhere(QueryBuilder.in(KeyByAccountColumns.ACCOUNT_ID.getName(), id))
                            .value(KeyByAccountColumns.KEY, key)
@@ -315,7 +330,9 @@ public class CascadingTest {
         
         //////////////////////////////////////
         // insert 
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());       
+        // 3.x API change
+        //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());    
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                        .value(KeyByAccountColumns.KEY, key)
                        .addSetValue(KeyByAccountColumns.EMAIL_IDX, idxType.newValue(email, time))
@@ -379,7 +396,9 @@ public class CascadingTest {
         
         //////////////////////////////////////
         // insert 
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());        
+        // 3.x API change
+        //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());     
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                        .value(KeyByAccountColumns.KEY, key)
                        .addSetValue(KeyByAccountColumns.EMAIL_IDX, idxType.newValue(email, time))
@@ -440,7 +459,9 @@ public class CascadingTest {
         //////////////////////////////////////
         // insert 
         try {
-            TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());            
+        	// 3.x API change
+            //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());
+        	TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
             keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                            .value(KeyByAccountColumns.KEY, key)
                            .addSetValue(KeyByAccountColumns.EMAIL_IDX, idxType.newValue(email, time))
@@ -467,7 +488,9 @@ public class CascadingTest {
 
         //////////////////////////////////////
         // insert 
-        TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());        
+        // 3.x API change
+        //TupleType idxType = TupleType.of(DataType.text(), DataType.bigint());        
+        TupleType idxType = TupleType.of(protocolVersion, codecRegistry,DataType.text(), DataType.bigint());
         keyByAccountDao.writeWithKey(KeyByAccountColumns.ACCOUNT_ID, id)
                        .value(KeyByAccountColumns.KEY, key)
                        .addSetValue(KeyByAccountColumns.EMAIL_IDX, idxType.newValue(email, time))

--- a/troilus-core/src/test/java/net/oneandone/troilus/persistence/EntityInheritanceMappingTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/persistence/EntityInheritanceMappingTest.java
@@ -1,0 +1,216 @@
+/**
+ * 
+ */
+package net.oneandone.troilus.persistence;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+import net.oneandone.troilus.CassandraDB;
+import net.oneandone.troilus.Dao;
+import net.oneandone.troilus.DaoImpl;
+import net.oneandone.troilus.Field;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+
+
+/**
+ * Tests ability to map to an entity with inherited @Field(s)
+ * 
+ * @author Jason Westra  12-10-2015
+ * 
+ *
+ */
+@RunWith(value=BlockJUnit4ClassRunner.class)
+public class EntityInheritanceMappingTest extends TestCase {
+
+	
+	private static CassandraDB cassandra;
+	 
+	Session session;
+	
+	public static final String keyspace = "ks_"+System.currentTimeMillis();
+	public static final String TABLE_MOCK_WITH_INHERITANCE = "mock_with_inheritance";
+		
+	@BeforeClass
+    public static void beforeClass() throws IOException {
+        cassandra = CassandraDB.newInstance();
+        
+        dropKeyspace();
+		createKeyspace();
+		createTables();	
+    }
+        
+    @AfterClass
+    public static void afterClass() throws IOException {
+    	dropKeyspace();
+        cassandra.close();
+    }
+	    
+	@Before
+	public void setUp() throws Exception {
+		session = cassandra.getSession();
+	}
+		
+	private static void createKeyspace() {
+		cassandra.getSession().execute("CREATE KEYSPACE "+keyspace+" with replication={'class': 'SimpleStrategy', 'replication_factor' : 1};");
+	}
+
+	private static void createTables() {
+		Session session = cassandra.getSession();
+		
+		session.execute("CREATE TABLE "+keyspace+"."+TABLE_MOCK_WITH_INHERITANCE+" (id text, version bigint, create_date timestamp, latitude decimal, PRIMARY KEY (id));");
+	}
+	
+	private static void dropKeyspace() {
+		try {
+			Session session = cassandra.getSession();
+			session.execute("DROP KEYSPACE "+keyspace+";");
+		} catch(Exception e) {
+			
+		}
+	}
+	
+		
+	@Test
+	public void testEntityWithInheritance() {
+		
+		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_INHERITANCE);
+				
+		MockDOWithInheritance mockDOWithInheritance = new MockDOWithInheritance();
+		mockDOWithInheritance.setCreateDate(new Date());
+		mockDOWithInheritance.setId("some_id");
+		mockDOWithInheritance.setVersion(1);
+		mockDOWithInheritance.setLatitude(new BigDecimal("23"));
+		
+		// insert here
+		dao.writeEntity(mockDOWithInheritance)
+			.ifNotExists()
+			.execute();
+		
+		com.datastax.driver.core.ResultSet rs =session.execute("select * from "+keyspace+"."+TABLE_MOCK_WITH_INHERITANCE);
+		if (rs.one() == null) fail("Failed to insert the row");
+		
+		mockDOWithInheritance.setLatitude(new BigDecimal(44));
+		mockDOWithInheritance.setVersion(2);
+		
+		// update here
+		try {
+			dao.writeWithKey("id", mockDOWithInheritance.getId())
+			.entity(mockDOWithInheritance)
+			.onlyIf(QueryBuilder.eq("version", mockDOWithInheritance.getVersion() - 1))
+			.execute();
+		} catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+		
+		// find one here
+		MockDOWithInheritance afterUpdate = dao.readWithKey("id", mockDOWithInheritance.getId())
+			.asEntity(MockDOWithInheritance.class)
+			.execute().get();
+		
+		assertEquals("Did not update version", 2, afterUpdate.getVersion());
+		assertEquals("Did not update latitude", mockDOWithInheritance.getLatitude(), afterUpdate.getLatitude());
+		
+		dao.deleteWithKey("id", mockDOWithInheritance.getId()).execute();
+		
+		Optional<MockDOWithInheritance> afterDelete = dao.readWithKey("id", mockDOWithInheritance.getId())
+				.asEntity(MockDOWithInheritance.class)
+				.execute();
+		
+		assertFalse("Delete did not work", afterDelete.isPresent());
+	}
+	
+	// Tests @Field shows up on subclasses
+	abstract public static class AbstractDO {
+		
+		@Field(name="id")
+		private String id;
+				
+		@Field(name="create_date")
+		private Date createDate;
+				
+		@Field(name="version")
+		private long version;
+
+		/**
+		 * @return the id
+		 */
+		public String getId() {
+			return id;
+		}
+
+		/**
+		 * @param id the id to set
+		 */
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		/**
+		 * @return the createDate
+		 */
+		public Date getCreateDate() {
+			return createDate;
+		}
+
+		/**
+		 * @param createDate the createDate to set
+		 */
+		public void setCreateDate(Date createDate) {
+			this.createDate = createDate;
+		}
+
+		/**
+		 * @return the version
+		 */
+		public long getVersion() {
+			return version;
+		}
+
+		/**
+		 * @param version the version to set
+		 */
+		public void setVersion(long version) {
+			this.version = version;
+		}
+	}
+	
+	// Inherits to get common fields like id, audit, and version
+	public static class MockDOWithInheritance extends AbstractDO {
+		
+		@Field(name="latitude")
+		private BigDecimal latitude;
+
+		/**
+		 * @return the latitude
+		 */
+		public BigDecimal getLatitude() {
+			return latitude;
+		}
+
+		/**
+		 * @param latitude the latitude to set
+		 */
+		public void setLatitude(BigDecimal latitude) {
+			this.latitude = latitude;
+		}
+	}
+	
+	
+	
+	
+}

--- a/troilus-core/src/test/java/net/oneandone/troilus/persistence/EntityInheritanceMappingTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/persistence/EntityInheritanceMappingTest.java
@@ -29,7 +29,7 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 /**
  * Tests ability to map to an entity with inherited @Field(s)
  * 
- * @author Jason Westra  12-10-2015
+ * @author Jason Westra  12-13-2015
  * 
  *
  */
@@ -106,7 +106,7 @@ public class EntityInheritanceMappingTest extends TestCase {
 		mockDOWithInheritance.setLatitude(new BigDecimal(44));
 		mockDOWithInheritance.setVersion(2);
 		
-		// update here
+		// update here demonstrating onlyIf() on the version
 		try {
 			dao.writeWithKey("id", mockDOWithInheritance.getId())
 			.entity(mockDOWithInheritance)

--- a/troilus-core/src/test/java/net/oneandone/troilus/referentialintegrity/PhonenumbersConstraints.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/referentialintegrity/PhonenumbersConstraints.java
@@ -22,10 +22,10 @@ package net.oneandone.troilus.referentialintegrity;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import net.oneandone.troilus.ConstraintException;
 import net.oneandone.troilus.Dao;
 import net.oneandone.troilus.FetchingIterator;
 import net.oneandone.troilus.Record;
-import net.oneandone.troilus.ConstraintException;
 import net.oneandone.troilus.ResultList;
 import net.oneandone.troilus.interceptor.ReadQueryData;
 import net.oneandone.troilus.interceptor.ReadQueryRequestInterceptor;
@@ -33,10 +33,16 @@ import net.oneandone.troilus.interceptor.ReadQueryResponseInterceptor;
 import net.oneandone.troilus.interceptor.RecordListAdapter;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ResultSet;
 import com.google.common.collect.ImmutableSet;
     
 
-
+/**
+ * 
+ * @author Jason Westra - edited original
+ * 12-12-2015: 3.x API change - CompletableFuture<Void> to CompletableFuture<ResultSet>
+ *
+ */
 class PhonenumbersConstraints implements ReadQueryRequestInterceptor,
                                          ReadQueryResponseInterceptor {
     
@@ -92,7 +98,7 @@ class PhonenumbersConstraints implements ReadQueryRequestInterceptor,
                 return it.isFullyFetched();
             }
             
-            public CompletableFuture<Void> fetchMoreResultsAsync() {
+            public CompletableFuture<ResultSet> fetchMoreResultsAsync() {
                 return it.fetchMoreResultsAsync();
             }
             

--- a/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
@@ -1,0 +1,480 @@
+/**
+ * 
+ */
+package net.oneandone.troilus.userdefinieddatatypes;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import junit.framework.TestCase;
+import net.oneandone.troilus.CassandraDB;
+import net.oneandone.troilus.Dao;
+import net.oneandone.troilus.DaoImpl;
+import net.oneandone.troilus.Field;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+import com.datastax.driver.core.Session;
+
+
+
+/**
+ * Tests APIs against Single embedded UDT, List of UDT, Set of UDT and Map of UDT
+ * 
+ * Hotels example only tests collections with native DataTypes
+ * UserDefinedDataTypesTest.java does not test updating and entity with Collections of UDTValue
+ * 
+ * @author Jason Westra 12-10-2015
+ *
+ */
+@RunWith(value=BlockJUnit4ClassRunner.class)
+public class UDTValueMappingCollectionTests extends TestCase {
+
+	
+	private static CassandraDB cassandra;
+	 
+	Session session;
+	
+	public static final String keyspace = "ks_"+System.currentTimeMillis();
+	
+	public static final String TABLE_MOCK_WITH_UDT_LIST = "mock_with_udt_list";
+	public static final String TABLE_MOCK_WITH_UDT_SET = "mock_with_udt_set";
+	public static final String TABLE_MOCK_WITH_UDT_MAP = "mock_with_udt_map";
+	public static final String TABLE_MOCK_WITH_UDT = "mock_with_udt_single";
+	
+	@BeforeClass
+    public static void beforeClass() throws IOException {
+        cassandra = CassandraDB.newInstance();
+        
+        dropKeyspace();
+		createKeyspace();
+		createUDTs();
+		createTables();	
+    }
+        
+    @AfterClass
+    public static void afterClass() throws IOException {
+    	dropKeyspace();
+        cassandra.close();
+    }
+	    
+	@Before
+	public void setUp() throws Exception {
+		session = cassandra.getSession();
+		
+	}
+		
+	private static void createKeyspace() {
+		cassandra.getSession().execute("CREATE KEYSPACE "+keyspace+" with replication={'class': 'SimpleStrategy', 'replication_factor' : 1};");
+	}
+
+	private static void createTables() {
+		Session session = cassandra.getSession();
+		
+		session.execute("CREATE TABLE "+keyspace+"."+TABLE_MOCK_WITH_UDT_LIST+" (id text, version bigint, create_date timestamp, descriptions list<frozen<description>>, PRIMARY KEY (id));");
+		session.execute("CREATE TABLE "+keyspace+"."+TABLE_MOCK_WITH_UDT_SET+" (id text, version bigint, create_date timestamp, descriptions set<frozen<description>>, PRIMARY KEY (id));");
+		session.execute("CREATE TABLE "+keyspace+"."+TABLE_MOCK_WITH_UDT_MAP+" (id text, version bigint, create_date timestamp, descriptions map<text,frozen<description>>, PRIMARY KEY (id));");
+		session.execute("CREATE TABLE "+keyspace+"."+TABLE_MOCK_WITH_UDT+" (id text, version bigint, create_date timestamp, description frozen<description>, PRIMARY KEY (id));");
+	}
+	
+	
+	private static void createUDTs() {
+		Session session = cassandra.getSession();
+		session.execute("CREATE TYPE "+keyspace+".description (name text, time timestamp)");
+	}
+
+	private static void dropKeyspace() {
+		try {
+			Session session = cassandra.getSession();
+			session.execute("DROP KEYSPACE "+keyspace+";");
+		} catch(Exception e) {
+			
+		}
+	}
+	
+	@Test
+	public void testEntityWithUDTSingle() throws Exception {
+		MockDOWithUDTSingle dataObject = new MockDOWithUDTSingle();
+		dataObject.setCreateDate(new Date());
+		dataObject.setId(System.currentTimeMillis()+"");
+		dataObject.setVersion(1);
+		
+		DescriptionUDT description = new DescriptionUDT();
+		description.name = "someName";
+		description.time = new Date();
+		
+		dataObject.setDescription(description);
+		
+		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_LIST);
+		dao.writeEntity(dataObject)
+			.ifNotExists()
+			.execute();
+		
+		MockDOWithUDTSingle entityAsInserted = null;
+		try {
+			entityAsInserted = dao.readWithKey("id", dataObject.getId())
+					.asEntity(MockDOWithUDTSingle.class)
+					.execute().get();
+		} catch(Exception e) {
+			e.printStackTrace();
+			// if will fail on assert below
+		}
+		
+		assertNotNull(entityAsInserted);
+	}
+		
+	@Test
+	public void testEntityWithUDTList() throws Exception {
+		MockDOWithUDTList dataObject = new MockDOWithUDTList();
+		dataObject.setCreateDate(new Date());
+		dataObject.setId(System.currentTimeMillis()+"");
+		dataObject.setVersion(1);
+		
+		DescriptionUDT description1 = new DescriptionUDT();
+		description1.name = "someName1";
+		description1.time = new Date();
+		
+		DescriptionUDT description2 = new DescriptionUDT();
+		description2.name = "someName2";
+		description2.time = new Date();
+				
+		ArrayList<DescriptionUDT> descriptions = new ArrayList<DescriptionUDT>(); 
+		descriptions.add(description1);
+		descriptions.add(description2);
+		
+		dataObject.setDescriptions(descriptions);
+		
+		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_LIST);
+		dao.writeEntity(dataObject)
+			.ifNotExists()
+			.execute();
+		
+		MockDOWithUDTList entityAsInserted = null;
+		try {
+			entityAsInserted = dao.readWithKey("id", dataObject.getId())
+					.asEntity(MockDOWithUDTList.class)
+					.execute().get();
+		} catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+		
+		assertNotNull(entityAsInserted);
+		assertTrue(entityAsInserted.getDescriptions().size() == 2);
+		
+	}
+	
+	@Test
+	public void testEntityWithUDTSet() throws Exception {
+		MockDOWithUDTSet dataObject = new MockDOWithUDTSet();
+		dataObject.setCreateDate(new Date());
+		dataObject.setId(System.currentTimeMillis()+"");
+		dataObject.setVersion(1);
+		
+		DescriptionUDT description1 = new DescriptionUDT();
+		description1.name = "someName1";
+		description1.time = new Date();
+		
+		DescriptionUDT description2 = new DescriptionUDT();
+		description2.name = "someName2";
+		description2.time = new Date();
+				
+		HashSet<DescriptionUDT> descriptions = new HashSet<DescriptionUDT>(); 
+		descriptions.add(description1);
+		descriptions.add(description2);
+		
+		dataObject.setDescriptions(descriptions);
+		
+		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_SET);
+		dao.writeEntity(dataObject)
+			.ifNotExists()
+			.execute();
+		
+		MockDOWithUDTSet entityAsInserted = null;
+		try {
+			entityAsInserted = dao.readWithKey("id", dataObject.getId())
+					.asEntity(MockDOWithUDTSet.class)
+					.execute().get();
+		} catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+		
+		assertNotNull(entityAsInserted);
+		assertTrue(entityAsInserted.getDescriptions().size() == 2);
+		
+	}
+	
+	@Test
+	public void testEntityWithUDTMap() throws Exception {
+		MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
+		dataObject.setCreateDate(new Date());
+		dataObject.setId(System.currentTimeMillis()+"");
+		dataObject.setVersion(1);
+		
+		DescriptionUDT description1 = new DescriptionUDT();
+		description1.name = "someName1";
+		description1.time = new Date();
+		
+		DescriptionUDT description2 = new DescriptionUDT();
+		description2.name = "someName2";
+		description2.time = new Date();
+				
+		Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>(); 
+		descriptions.put("1", description1);
+		descriptions.put("2", description2);
+		
+		dataObject.setDescriptions(descriptions);
+		
+		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		dao.writeEntity(dataObject)
+			.ifNotExists()
+			.execute();
+		
+		MockDOWithUDTMap entityAsInserted = null;
+		try {
+			entityAsInserted = dao.readWithKey("id", dataObject.getId())
+					.asEntity(MockDOWithUDTMap.class)
+					.execute().get();
+		} catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+		
+		assertNotNull(entityAsInserted);
+		assertTrue(entityAsInserted.getDescriptions().size() == 2);
+		
+	}
+	
+	
+	
+
+	
+	
+	// Tests @Field shows up on subclasses
+	abstract public static class AbstractDO {
+		
+		@Field(name="id")
+		private String id;
+				
+		@Field(name="create_date")
+		private Date createDate;
+				
+		@Field(name="version")
+		private long version;
+
+		/**
+		 * @return the id
+		 */
+		public String getId() {
+			return id;
+		}
+
+		/**
+		 * @param id the id to set
+		 */
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		/**
+		 * @return the createDate
+		 */
+		public Date getCreateDate() {
+			return createDate;
+		}
+
+		/**
+		 * @param createDate the createDate to set
+		 */
+		public void setCreateDate(Date createDate) {
+			this.createDate = createDate;
+		}
+
+		/**
+		 * @return the version
+		 */
+		public long getVersion() {
+			return version;
+		}
+
+		/**
+		 * @param version the version to set
+		 */
+		public void setVersion(long version) {
+			this.version = version;
+		}
+	}
+	
+	public static class MockDOWithInheritance extends AbstractDO {
+		
+		@Field(name="latitude")
+		private BigDecimal latitude;
+
+		/**
+		 * @return the latitude
+		 */
+		public BigDecimal getLatitude() {
+			return latitude;
+		}
+
+		/**
+		 * @param latitude the latitude to set
+		 */
+		public void setLatitude(BigDecimal latitude) {
+			this.latitude = latitude;
+		}
+	}
+	
+	public static class MockDOWithUDTList extends AbstractDO {
+		
+		@Field(name="descriptions")
+		private List<DescriptionUDT> descriptions;
+
+		/**
+		 * @return the descriptions
+		 */
+		public List<DescriptionUDT> getDescriptions() {
+			return descriptions;
+		}
+
+		/**
+		 * @param descriptions the descriptions to set
+		 */
+		public void setDescriptions(List<DescriptionUDT> descriptions) {
+			this.descriptions = descriptions;
+		}
+	}
+	
+	public static class MockDOWithUDTSet extends AbstractDO {
+		
+		@Field(name="descriptions")
+		private Set<DescriptionUDT> descriptions;
+
+		/**
+		 * @return the descriptions
+		 */
+		public Set<DescriptionUDT> getDescriptions() {
+			return descriptions;
+		}
+
+		/**
+		 * @param descriptions the descriptions to set
+		 */
+		public void setDescriptions(Set<DescriptionUDT> descriptions) {
+			this.descriptions = descriptions;
+		}
+	}
+	
+	public static class MockDOWithUDTMap extends AbstractDO {
+		
+		@Field(name="descriptions")
+		private Map<String, DescriptionUDT> descriptions;
+
+		/**
+		 * @return the descriptions
+		 */
+		public Map<String, DescriptionUDT> getDescriptions() {
+			return descriptions;
+		}
+
+		/**
+		 * @param descriptions the descriptions to set
+		 */
+		public void setDescriptions(Map<String, DescriptionUDT> descriptions) {
+			this.descriptions = descriptions;
+		}
+	}
+	
+	public static class MockDOWithUDTSingle extends AbstractDO {
+		
+		@Field(name="description")
+		DescriptionUDT description;
+
+		/**
+		 * @return the description
+		 */
+		public DescriptionUDT getDescription() {
+			return description;
+		}
+
+		/**
+		 * @param description the description to set
+		 */
+		public void setDescription(DescriptionUDT description) {
+			this.description = description;
+		}
+	}
+	
+	
+	// The User Defined Type
+	public static class DescriptionUDT {
+		
+		@Field(name="name")
+		private String name;
+		
+		@Field(name="time")
+		private Date time;
+
+		/**
+		 * @return the name
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * @param name the name to set
+		 */
+		public void setName(String name) {
+			if (name == null) throw new IllegalArgumentException("name cannot be empty");
+			this.name = name;
+		}
+
+		/**
+		 * @return the time
+		 */
+		public Date getTime() {
+			return time;
+		}
+
+		/**
+		 * @param time the time to set
+		 */
+		public void setTime(Date time) {
+			if (time == null) throw new IllegalArgumentException("time cannot be empty");
+			this.time = time;
+		}
+		
+		//////////////////////////////////////////////
+		// REQUIRED FOR UDT THAT IS IN A SET
+		// SMART TO HAVE REGARDLESS....
+		//////////////////////////////////////////////
+		public int hashCode() {
+			return (this.time.hashCode() * 37) + (this.name.hashCode() * 37);
+		}
+		
+		public boolean equals(Object o) {
+			if (o instanceof DescriptionUDT) {
+				DescriptionUDT other = (DescriptionUDT)o;
+				if (other.time.equals(this.time) &&
+						other.name.equals(this.name)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/troilus-core/src/test/resources/com/unitedinternet/troilus/example/invites.ddl
+++ b/troilus-core/src/test/resources/com/unitedinternet/troilus/example/invites.ddl
@@ -1,0 +1,9 @@
+DROP TABLE invites_by_group;
+
+CREATE TABLE invites_by_group (
+  group_id text,
+  invite_date timestamp,
+  email_address text,
+  PRIMARY KEY (group_id, invite_date, email_address)
+)
+WITH CLUSTERING ORDER BY (invite_date ASC);


### PR DESCRIPTION
Hi!,

I forked the Troilus 0.17-SNAPSHOT to fix some bugs, upgrade to Cassandra 3.x driver APIs which uses TypeCodec and CodecRegistry for serialization/deserialization instead of DataType APIs, and other enhancements, which is required by our company, Kritek, LLC.  I'd like to have my fork upgrades and bug fixes included in the original Troilus project, so my company can stay in-line with your releases and not diverge even further on our own fork.  

I am not clear on the process here, but my understanding is that I make a Pull Request, which needs approval for inclusion.

Here are the items I have added to the Kritek Fork (from the changes.txt).
## 0.17 - Kritek Fork
- Pagination Support - ListRead.withPagingState(), ListReadQuery.toStatementAsync()
- Inheritance of @Field mappings for entities in BeanMapper
- Upgrade from Cassandra Datastax 2.2.0-rc2 driver to 3.0.0-beta1 driver
- Upgrade tests from Cassandra 2.x to Cassandra 3.0.0 (see pom.xml dependency and CassandraDB.java)
- LocalDateTime Support - Record.java interfaces and implementations
- bugfix: WriteQueryDataImpl.java toUpdateStatementAsync() no longer maps primary keys into Update SET
- bugfix: RecordImpl.PropertySourceAdapter rewrote read() and read(String name, Class<?> clazz1, Class<?> clazz2) to work with UDTValue collections.
- New test cases: PaginationTest.java, EntityInheritanceMappingTest.java, UDTValueMappingCollectionTests.java
## POMs

The original poms referenced some dependencies that did not exist in Maven Central.  They were changed as follows in my forked version.

<dependency>
    <groupId>org.reactivestreams</groupId>
    <artifactId>reactive-streams</artifactId>
    <version>1.0.0.final</version>  **changed to 1.0.0**
</dependency>
<dependency>
    <groupId>org.reactivestreams</groupId>
    <artifactId>reactive-streams-tck</artifactId>
    <version>1.0.0.final</version>
    <scope>test</scope>  **changed to 1.0.0**
</dependency>

I also created Maven properties for some of the version, as well, for clarity and reuse.
## Tests

I ran all tests individually from the Eclipse IDE.  They all run 100%.  However, when running from commandline using "mvn test", they fail because the Surefire plugin does not process the JUnit @RunWith annotation properly.
## Logging

I have not included any extra SLF4J logging yet.  However, I believe more logging in Troilus will benefit troubleshooting issues with the framework as well as code calling it.  It was quite time-consuming troubleshooting all the asynchronous, futures calls in the debugger :)  I'd be interested in hearing where your thoughts are on this topic as well.
