### PR TITLE
Modification to add/remove UDT values to map type

### DIFF
--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQuery.java
@@ -17,21 +17,25 @@ package net.oneandone.troilus;
 
 
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-
-
 import net.oneandone.troilus.interceptor.DeleteQueryData;
-import net.oneandone.troilus.java7.Deletion;
 import net.oneandone.troilus.java7.Batchable;
+import net.oneandone.troilus.java7.Deletion;
 import net.oneandone.troilus.java7.interceptor.CascadeOnDeleteInterceptor;
 import net.oneandone.troilus.java7.interceptor.DeleteQueryRequestInterceptor;
 
-import com.datastax.driver.core.querybuilder.Clause;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.Clause;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -87,6 +91,38 @@ class DeleteQuery extends MutationQuery<Deletion> implements Deletion {
         return newQuery(data.ifExists(true));
     }
         
+    /**
+     * this method builds DeleteQuery of map entries to be removed from 
+     * a map column or map columns
+     * 
+     * @param columnName
+     * @param mapKey
+     * @return
+     */
+    @Override
+    public DeleteQuery removeMapValue(String columnName, Object mapKey) {
+    	
+    	Map<String, List<Object>> persistentMap = data.getMapValuesToRemove() !=null ? 
+    			Maps.newHashMap(data.getMapValuesToRemove()) : new HashMap<String, List<Object>>();
+    			
+    	//if map value exists, get existing values and add the new one if not a duplicate
+    	if(mapKey!=null) {
+    		List<Object> list = new ArrayList<Object>();
+    		if(data.getMapValuesToRemove() !=null) {
+    			List<Object> existingList = data.getMapValuesToRemove().get(columnName);
+    			if(existingList !=null) {
+    				list.addAll(existingList);
+    			}
+    		}
+    		if(!list.contains(mapKey)) {
+    			list.add(mapKey);
+    		}
+    		persistentMap.put(columnName, list);
+    	}
+    	ImmutableMap<String, List<Object>> map = ImmutableMap.copyOf(persistentMap);
+    	return newQuery(data.mapValuesToRemove(map));
+    }
+    
     @Override
     public ListenableFuture<Result> executeAsync() {
         ListenableFuture<Result> future = super.executeAsync();

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQuery.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQuery.java
@@ -17,25 +17,21 @@ package net.oneandone.troilus;
 
 
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
+
+
 import net.oneandone.troilus.interceptor.DeleteQueryData;
-import net.oneandone.troilus.java7.Batchable;
 import net.oneandone.troilus.java7.Deletion;
+import net.oneandone.troilus.java7.Batchable;
 import net.oneandone.troilus.java7.interceptor.CascadeOnDeleteInterceptor;
 import net.oneandone.troilus.java7.interceptor.DeleteQueryRequestInterceptor;
 
-import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Clause;
+import com.datastax.driver.core.Statement;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -90,43 +86,7 @@ class DeleteQuery extends MutationQuery<Deletion> implements Deletion {
     public DeleteQuery ifExists() {
         return newQuery(data.ifExists(true));
     }
-    
-    /**
-     * this method builds DeleteQuery of map entries to be removed from 
-     * a map column or map columns
-     * 
-     * @param columnName
-     * @param mapKey
-     * @return
-     */
-    @Override
-    public DeleteQuery removeMapValue(String columnName, Object mapKey) {
-    	
-    	Map<String, List<Object>> persistentMap = data.getMapValuesToRemove() !=null ? 
-    			Maps.newHashMap(data.getMapValuesToRemove()) : new HashMap<String, List<Object>>();
-    			
-    	//if map value exists, get existing values and add the new one if not a duplicate
-    	if(mapKey!=null) {
-    		List<Object> list = new ArrayList<Object>();
-    		if(data.getMapValuesToRemove() !=null) {
-    			List<Object> existingList = data.getMapValuesToRemove().get(columnName);
-    			if(existingList !=null) {
-    				list.addAll(existingList);
-    			}
-    		}
-    		if(!list.contains(mapKey)) {
-    			list.add(mapKey);
-    		}
-    		persistentMap.put(columnName, list);
-    	}
-    	ImmutableMap<String, List<Object>> map = ImmutableMap.copyOf(persistentMap);
-    	return newQuery(data.mapValuesToRemove(map));
-    }
-    
-    
-    
-    
-    
+        
     @Override
     public ListenableFuture<Result> executeAsync() {
         ListenableFuture<Result> future = super.executeAsync();

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQueryDataImpl.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQueryDataImpl.java
@@ -49,7 +49,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
     private final ImmutableList<Clause> whereConditions;
     private final ImmutableList<Clause> onlyIfConditions;
     private final Boolean ifExists;
-     
+    private final ImmutableMap<String, List<Object>> mapValuesToRemove;
 
     /**
      * constructor 
@@ -59,6 +59,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
              ImmutableMap.<String, Object>of(), 
              ImmutableList.<Clause>of(), 
              ImmutableList.<Clause>of(),
+             null, 
              null);
     }
     
@@ -66,12 +67,14 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                 ImmutableMap<String, Object> keyNameValuePairs, 
                                 ImmutableList<Clause> whereConditions, 
                                 ImmutableList<Clause> onlyIfConditions,
-                                Boolean ifExists) {
+                                Boolean ifExists,
+                                ImmutableMap<String, List<Object>> mapValuesToRemove) {
         this.tablename = tablename;
         this.keyNameValuePairs = keyNameValuePairs;
         this.whereConditions = whereConditions;
         this.onlyIfConditions = onlyIfConditions;
         this.ifExists = ifExists;
+        this.mapValuesToRemove = mapValuesToRemove;
     }
     
     @Override
@@ -80,7 +83,8 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        keyNameValuePairs, 
                                        this.whereConditions, 
                                        this.onlyIfConditions,
-                                       this.ifExists);  
+                                       this.ifExists,
+                                       this.mapValuesToRemove);  
     }
     
     @Override
@@ -89,7 +93,8 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        whereConditions, 
                                        this.onlyIfConditions,
-                                       this.ifExists);  
+                                       this.ifExists,
+                                       this.mapValuesToRemove);  
     }
     
     @Override
@@ -98,7 +103,8 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        this.whereConditions, 
                                        onlyIfConditions,
-                                       this.ifExists);  
+                                       this.ifExists, 
+                                       this.mapValuesToRemove);  
     }
     
     @Override
@@ -107,7 +113,18 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        this.whereConditions, 
                                        this.onlyIfConditions,
-                                       ifExists);  
+                                       ifExists, 
+                                       this.mapValuesToRemove);  
+    }
+    
+    @Override
+    public DeleteQueryDataImpl mapValuesToRemove(ImmutableMap<String, List<Object>> mapValuesToRemove) {
+    	return new DeleteQueryDataImpl(this.tablename,
+    									this.keyNameValuePairs,
+    									this.whereConditions,
+    									onlyIfConditions,
+    									this.ifExists,
+    									mapValuesToRemove);
     }
     
     @Override
@@ -135,6 +152,10 @@ class DeleteQueryDataImpl implements DeleteQueryData {
         return ifExists;
     }
     
+    @Override
+    public ImmutableMap<String, List<Object>> getMapValuesToRemove() {
+    	return mapValuesToRemove;
+    }
 
     /**
      * @param data  the data 
@@ -143,8 +164,9 @@ class DeleteQueryDataImpl implements DeleteQueryData {
      */
     static ListenableFuture<Statement> toStatementAsync(DeleteQueryData data, ExecutionSpec executionSpec, UDTValueMapper udtValueMapper, DBSession dbSession) {
         
-        Delete delete = (data.getTablename().getKeyspacename() == null) ? delete().from(data.getTablename().getTablename())
-                                                                        : delete().from(data.getTablename().getKeyspacename(), data.getTablename().getTablename());
+    	Delete.Selection deletion = delete();
+        Delete delete = (data.getTablename().getKeyspacename() == null) ? deletion.from(data.getTablename().getTablename())
+                                                                        : deletion.from(data.getTablename().getKeyspacename(), data.getTablename().getTablename());
 
         for (Clause onlyIfCondition : data.getOnlyIfConditions()) {
             delete.onlyIf(onlyIfCondition);
@@ -152,6 +174,14 @@ class DeleteQueryDataImpl implements DeleteQueryData {
         
         if ((data.getIfExists() != null) && data.getIfExists()) {
             delete.ifExists();
+        }
+        
+        if(data.getMapValuesToRemove() !=null) {
+        	for(Entry<String, List<Object>> entry : data.getMapValuesToRemove().entrySet()) {
+        		for(Object object : entry.getValue()) {
+        			deletion.mapElt(entry.getKey(), object);
+        		}
+        	}
         }
         
         // key-based delete    

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQueryDataImpl.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/DeleteQueryDataImpl.java
@@ -49,7 +49,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
     private final ImmutableList<Clause> whereConditions;
     private final ImmutableList<Clause> onlyIfConditions;
     private final Boolean ifExists;
-    private final ImmutableMap<String, List<Object>> mapValuesToRemove;
+     
 
     /**
      * constructor 
@@ -59,7 +59,6 @@ class DeleteQueryDataImpl implements DeleteQueryData {
              ImmutableMap.<String, Object>of(), 
              ImmutableList.<Clause>of(), 
              ImmutableList.<Clause>of(),
-             null, 
              null);
     }
     
@@ -67,14 +66,12 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                 ImmutableMap<String, Object> keyNameValuePairs, 
                                 ImmutableList<Clause> whereConditions, 
                                 ImmutableList<Clause> onlyIfConditions,
-                                Boolean ifExists,
-                                ImmutableMap<String, List<Object>> mapValuesToRemove) {
+                                Boolean ifExists) {
         this.tablename = tablename;
         this.keyNameValuePairs = keyNameValuePairs;
         this.whereConditions = whereConditions;
         this.onlyIfConditions = onlyIfConditions;
         this.ifExists = ifExists;
-        this.mapValuesToRemove = mapValuesToRemove;
     }
     
     @Override
@@ -83,8 +80,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        keyNameValuePairs, 
                                        this.whereConditions, 
                                        this.onlyIfConditions,
-                                       this.ifExists,
-                                       this.mapValuesToRemove);  
+                                       this.ifExists);  
     }
     
     @Override
@@ -93,8 +89,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        whereConditions, 
                                        this.onlyIfConditions,
-                                       this.ifExists,
-                                       this.mapValuesToRemove);  
+                                       this.ifExists);  
     }
     
     @Override
@@ -103,8 +98,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        this.whereConditions, 
                                        onlyIfConditions,
-                                       this.ifExists, 
-                                       this.mapValuesToRemove);  
+                                       this.ifExists);  
     }
     
     @Override
@@ -113,18 +107,7 @@ class DeleteQueryDataImpl implements DeleteQueryData {
                                        this.keyNameValuePairs, 
                                        this.whereConditions, 
                                        this.onlyIfConditions,
-                                       ifExists, 
-                                       this.mapValuesToRemove);  
-    }
-    
-    @Override
-    public DeleteQueryDataImpl mapValuesToRemove(ImmutableMap<String, List<Object>> mapValuesToRemove) {
-    	return new DeleteQueryDataImpl(this.tablename,
-    									this.keyNameValuePairs,
-    									this.whereConditions,
-    									onlyIfConditions,
-    									this.ifExists,
-    									mapValuesToRemove);
+                                       ifExists);  
     }
     
     @Override
@@ -152,10 +135,6 @@ class DeleteQueryDataImpl implements DeleteQueryData {
         return ifExists;
     }
     
-    @Override
-    public ImmutableMap<String, List<Object>> getMapValuesToRemove() {
-    	return mapValuesToRemove;
-    }
 
     /**
      * @param data  the data 
@@ -164,9 +143,8 @@ class DeleteQueryDataImpl implements DeleteQueryData {
      */
     static ListenableFuture<Statement> toStatementAsync(DeleteQueryData data, ExecutionSpec executionSpec, UDTValueMapper udtValueMapper, DBSession dbSession) {
         
-    	Delete.Selection deletion = delete();
-        Delete delete = (data.getTablename().getKeyspacename() == null) ? deletion.from(data.getTablename().getTablename())
-                                                                        : deletion.from(data.getTablename().getKeyspacename(), data.getTablename().getTablename());
+        Delete delete = (data.getTablename().getKeyspacename() == null) ? delete().from(data.getTablename().getTablename())
+                                                                        : delete().from(data.getTablename().getKeyspacename(), data.getTablename().getTablename());
 
         for (Clause onlyIfCondition : data.getOnlyIfConditions()) {
             delete.onlyIf(onlyIfCondition);
@@ -174,14 +152,6 @@ class DeleteQueryDataImpl implements DeleteQueryData {
         
         if ((data.getIfExists() != null) && data.getIfExists()) {
             delete.ifExists();
-        }
-        
-        if(data.getMapValuesToRemove() !=null) {
-        	for(Entry<String, List<Object>> entry : data.getMapValuesToRemove().entrySet()) {
-        		for(Object object : entry.getValue()) {
-        			deletion.mapElt(entry.getKey(), object);
-        		}
-        	}
         }
         
         // key-based delete    

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/WriteQueryDataImpl.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/WriteQueryDataImpl.java
@@ -29,11 +29,10 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Map.Entry;
 
 import net.oneandone.troilus.java7.interceptor.WriteQueryData;
 
@@ -734,22 +733,7 @@ class WriteQueryDataImpl implements WriteQueryData {
 
             for(Entry<String, ImmutableMap<Object, Optional<Object>>> entry : data.getMapValuesToMutate().entrySet()) {
                 update.with(putAll(entry.getKey(), bindMarker())); 
-                
-                /**
-                 * Mike Wislocki - change 1/26/16
-                 * this change iterates through the map mutations and rebuids the map of objects 
-                 * in order to effectively create UDTValue.  Prior code was passing in the map key as 
-                 * opposed to the actual Map of objects to be converted into a UDT in the 
-                 * UDTValueMapper.toUdtValue method.  Otherwise a ClassCastException will be thrown at line 378
-                 */
-                Map<Object, Object> map = new HashMap<Object, Object>();
-                for(Entry<Object, Optional<Object>> thisEntry : entry.getValue().entrySet()) {
-                	Object object = thisEntry.getValue().isPresent() ? thisEntry.getValue().get() : null;
-                	if(object !=null) {
-                		map.put(thisEntry.getKey(), object);
-                	}
-                }
-                values.add(udtValueMapper.toStatementValue(data.getTablename(), entry.getKey(), map));
+                values.add(toStatementValue(udtValueMapper, data.getTablename(), entry.getKey(), entry.getValue()));
             }
             
             

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
@@ -17,11 +17,11 @@ package net.oneandone.troilus.interceptor;
 
 
 
+import java.util.List;
+
 import net.oneandone.troilus.Tablename;
 
 import com.datastax.driver.core.querybuilder.Clause;
-
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -45,6 +45,20 @@ public interface DeleteQueryData {
      */
     DeleteQueryData key(ImmutableMap<String, Object> key);
 
+    /**
+     * returns map of values to remove from column family
+     * @return
+     */
+    ImmutableMap<String, List<Object>> getMapValuesToRemove();
+    
+    /**
+     * this method's purpose is to populate the list of map 
+     * values to remove
+     * 
+     * @param removedMapValues
+     * @return
+     */
+    DeleteQueryData mapValuesToRemove(ImmutableMap<String, List<Object>> removedMapValues);
     /**
      * @param whereConditions the where conditions
      * @return the new delete query data

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
@@ -17,11 +17,11 @@ package net.oneandone.troilus.interceptor;
 
 
 
-import java.util.List;
-
 import net.oneandone.troilus.Tablename;
 
 import com.datastax.driver.core.querybuilder.Clause;
+
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -44,21 +44,6 @@ public interface DeleteQueryData {
      * @return the new delete query data
      */
     DeleteQueryData key(ImmutableMap<String, Object> key);
-    
-    /**
-     * returns map of values to remove from column family
-     * @return
-     */
-    ImmutableMap<String, List<Object>> getMapValuesToRemove();
-    
-    /**
-     * this method's purpose is to populate the list of map 
-     * values to remove
-     * 
-     * @param removedMapValues
-     * @return
-     */
-    DeleteQueryData mapValuesToRemove(ImmutableMap<String, List<Object>> removedMapValues);
 
     /**
      * @param whereConditions the where conditions

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/interceptor/DeleteQueryData.java
@@ -17,11 +17,11 @@ package net.oneandone.troilus.interceptor;
 
 
 
+import java.util.List;
+
 import net.oneandone.troilus.Tablename;
 
 import com.datastax.driver.core.querybuilder.Clause;
-
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -44,6 +44,21 @@ public interface DeleteQueryData {
      * @return the new delete query data
      */
     DeleteQueryData key(ImmutableMap<String, Object> key);
+    
+    /**
+     * returns map of values to remove from column family
+     * @return
+     */
+    ImmutableMap<String, List<Object>> getMapValuesToRemove();
+    
+    /**
+     * this method's purpose is to populate the list of map 
+     * values to remove
+     * 
+     * @param removedMapValues
+     * @return
+     */
+    DeleteQueryData mapValuesToRemove(ImmutableMap<String, List<Object>> removedMapValues);
 
     /**
      * @param whereConditions the where conditions

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Deletion.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Deletion.java
@@ -35,14 +35,4 @@ public interface Deletion extends Batchable<Deletion> {
      * @return a cloned query instance with lwt (if-exits)
      */
     Mutation<Deletion, Result> ifExists();
-    
-    /**
-     * this method will remove a provided map entry for a column 
-     * of type "map" in repository
-     * 
-     * @param columnName
-     * @param mapKey
-     * @return
-     */
-    Deletion removeMapValue(String columnName, Object mapKey);
 }

--- a/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Deletion.java
+++ b/troilus-core-java7/src/main/java/net/oneandone/troilus/java7/Deletion.java
@@ -35,4 +35,14 @@ public interface Deletion extends Batchable<Deletion> {
      * @return a cloned query instance with lwt (if-exits)
      */
     Mutation<Deletion, Result> ifExists();
+    
+    /**
+     * this method will remove a provided map entry for a column 
+     * of type "map" in repository
+     * 
+     * @param columnName
+     * @param mapKey
+     * @return
+     */
+    Deletion removeMapValue(String columnName, Object mapKey);
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
@@ -18,9 +18,6 @@ package net.oneandone.troilus;
 
 
 
-import net.oneandone.troilus.Context;
-import net.oneandone.troilus.DeleteQuery;
-
 import com.datastax.driver.core.querybuilder.Clause;
 
 
@@ -74,5 +71,10 @@ class DeleteQueryAdapter extends AbstractQueryAdapter<Deletion> implements Delet
     @Override
     public Deletion ifExists() {
         return newQuery(query.ifExists());
+    }
+    
+    @Override
+    public Deletion removeMapValue(String columnName, Object mapKey) {
+    	return newQuery(query.removeMapValue(columnName, mapKey));
     }
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
@@ -75,4 +75,9 @@ class DeleteQueryAdapter extends AbstractQueryAdapter<Deletion> implements Delet
     public Deletion ifExists() {
         return newQuery(query.ifExists());
     }
+    
+    @Override
+    public Deletion removeMapValue(String columnName, Object mapKey) {
+    	return newQuery(query.removeMapValue(columnName, mapKey));
+    }
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/DeleteQueryAdapter.java
@@ -75,9 +75,4 @@ class DeleteQueryAdapter extends AbstractQueryAdapter<Deletion> implements Delet
     public Deletion ifExists() {
         return newQuery(query.ifExists());
     }
-    
-    @Override
-    public Deletion removeMapValue(String columnName, Object mapKey) {
-    	return newQuery(query.removeMapValue(columnName, mapKey));
-    }
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/Deletion.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/Deletion.java
@@ -35,14 +35,4 @@ public interface Deletion extends Batchable<Deletion> {
      * @return a cloned query instance with lwt (if-exits)
      */
     Mutation<Deletion, Result> ifExists();
-    
-    /**
-     * this method will remove a provided map entry for a column 
-     * of type "map" in repository
-     * 
-     * @param columnName
-     * @param mapKey
-     * @return
-     */
-    Deletion removeMapValue(String columnName, Object mapKey);
 }

--- a/troilus-core/src/main/java/net/oneandone/troilus/Deletion.java
+++ b/troilus-core/src/main/java/net/oneandone/troilus/Deletion.java
@@ -35,4 +35,14 @@ public interface Deletion extends Batchable<Deletion> {
      * @return a cloned query instance with lwt (if-exits)
      */
     Mutation<Deletion, Result> ifExists();
+    
+    /**
+     * this method will remove a provided map entry for a column 
+     * of type "map" in repository
+     * 
+     * @param columnName
+     * @param mapKey
+     * @return
+     */
+    Deletion removeMapValue(String columnName, Object mapKey);
 }

--- a/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/api/PaginationTest.java
@@ -3,11 +3,11 @@
  */
 package net.oneandone.troilus.api;
 
-import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.io.IOException;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -24,7 +24,6 @@ import net.oneandone.troilus.ResultList;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import com.datastax.driver.core.PagingState;
 
@@ -189,13 +188,13 @@ public class PaginationTest implements PaginationInvites {
 	 * @return number of rows iterated over
 	 */
 	private int assertSortOrder(Iterator<Record> i) {
-		LocalDateTime previousInviteDate = null;
+		Date previousInviteDate = null;
 		int cnt = 0;
 		while(i.hasNext()) {
 			Record record = i.next();
-			LocalDateTime inviteDate = convert(record.getValue(INVITE_DATE, Date.class));
+			Date inviteDate = record.getValue(INVITE_DATE, Date.class);
 			if (previousInviteDate != null) {
-				if (previousInviteDate.isAfter(inviteDate)) {
+				if (previousInviteDate.after(inviteDate)) {
 					fail("Fetched out of order of the invite date");
 				}
 			}
@@ -212,14 +211,15 @@ public class PaginationTest implements PaginationInvites {
 	 */
 	private int assertSortOrder(ResultList<InvitesByMonthAndInviteDate> results) {
 		Iterator<InvitesByMonthAndInviteDate> i = results.iterator();
-		LocalDateTime previousInviteDate = null;
+		Date previousInviteDate = null;
 		int cnt = 0;
 		while(i.hasNext()) {
 			InvitesByMonthAndInviteDate invite = i.next();
 			
-			LocalDateTime inviteDate = invite.getInviteDate();
+			Date inviteDate = invite.getInviteDate();
 			if (previousInviteDate != null) {
-				if (previousInviteDate.isAfter(inviteDate)) {
+
+				if (previousInviteDate.after(inviteDate)) {
 					fail("Fetched out of order of the invite date");
 				}
 			}
@@ -240,7 +240,7 @@ public class PaginationTest implements PaginationInvites {
 		private String emailAddress;
 		
 		@Field(name="invite_date")
-		private LocalDateTime inviteDate;
+		private Date inviteDate;
 
 
 		/**
@@ -274,25 +274,17 @@ public class PaginationTest implements PaginationInvites {
 		/**
 		 * @return the inviteDate
 		 */
-		public LocalDateTime getInviteDate() {
+		public Date getInviteDate() {
 			return inviteDate;
 		}
 
 		/**
 		 * @param inviteDate the inviteDate to set
 		 */
-		public void setInviteDate(LocalDateTime inviteDate) {
+		public void setInviteDate(Date inviteDate) {
 			this.inviteDate = inviteDate;
 		}
 		
-	}
-	
-	
-	
-	private LocalDateTime convert(Date date) {
-		Instant instant = Instant.ofEpochMilli(date.getTime());
-		LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-		return ldt;
 	}
 
 }

--- a/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
@@ -220,245 +220,245 @@ public class UDTValueMappingCollectionTests extends TestCase {
 		
 	}
 	
-	@Test
-	public void testEntityWithUDTMap() throws Exception {
-		MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
-		dataObject.setCreateDate(new Date());
-		dataObject.setId(System.currentTimeMillis()+"");
-		dataObject.setVersion(1);
+	 @Test
+	 public void testEntityWithUDTMap() throws Exception {
+		 MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
+		 dataObject.setCreateDate(new Date());
+		 dataObject.setId(System.currentTimeMillis()+"");
+		 dataObject.setVersion(1);
+		 
+		 DescriptionUDT description1 = new DescriptionUDT();
+		 description1.name = "someName1";
+		 description1.time = new Date();
+		 
+		 DescriptionUDT description2 = new DescriptionUDT();
+		 description2.name = "someName2";
+		 description2.time = new Date();
+		 		
+		 Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>(); 
+		 descriptions.put("1", description1);
+		 descriptions.put("2", description2);
 		
-		DescriptionUDT description1 = new DescriptionUDT();
-		description1.name = "someName1";
-		description1.time = new Date();
+		 dataObject.setDescriptions(descriptions);
 		
-		DescriptionUDT description2 = new DescriptionUDT();
-		description2.name = "someName2";
-		description2.time = new Date();
-				
-		Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>(); 
-		descriptions.put("1", description1);
-		descriptions.put("2", description2);
+		 Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 dao.writeEntity(dataObject)
+		 	.ifNotExists()
+		 	.execute();
 		
-		dataObject.setDescriptions(descriptions);
-		
-		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-		dao.writeEntity(dataObject)
-			.ifNotExists()
-			.execute();
-		
-		MockDOWithUDTMap entityAsInserted = null;
-		try {
-			entityAsInserted = dao.readWithKey("id", dataObject.getId())
-					.asEntity(MockDOWithUDTMap.class)
-					.execute().get();
-		} catch(Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
-		
-		assertNotNull(entityAsInserted);
-		assertTrue(entityAsInserted.getDescriptions().size() == 2);
-		
-	}
+		 MockDOWithUDTMap entityAsInserted = null;
+		 try {
+		 	entityAsInserted = dao.readWithKey("id", dataObject.getId())
+		 			.asEntity(MockDOWithUDTMap.class)
+		 			.execute().get();
+		 } catch(Exception e) {
+		 	e.printStackTrace();
+		 	throw e;
+		 }
+		 
+		 assertNotNull(entityAsInserted);
+		 assertTrue(entityAsInserted.getDescriptions().size() == 2);
+	 	
+	 }
 	
-	/**
-	 * this method tests that the change to add an entry into a map 
-	 * succeeds
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testAddObjectsToMap() throws Exception {
-		MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
-		dataObject.setCreateDate(new Date());
-		dataObject.setId(System.currentTimeMillis()+"");
-		dataObject.setVersion(1);
+	 /**
+	  * this method tests that the change to add an entry into a map 
+	  * succeeds
+	  * 
+	  * @throws Exception
+	  */
+	 @Test
+	 public void testAddObjectsToMap() throws Exception {
+	     MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
+		 dataObject.setCreateDate(new Date());
+		 dataObject.setId(System.currentTimeMillis()+"");
+		 dataObject.setVersion(1);
+		 
+		 DescriptionUDT description1 = new DescriptionUDT();
+		 description1.name = "someName1";
+		 description1.time = new Date();
+		 
+		 DescriptionUDT description2 = new DescriptionUDT();
+		 description2.name = "someName2";
+		 description2.time = new Date();
+		 
+		 Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
+		 descriptions.put("1", description1);
+		 descriptions.put("2", description2);
 		
-		DescriptionUDT description1 = new DescriptionUDT();
-		description1.name = "someName1";
-		description1.time = new Date();
+		 dataObject.setDescriptions(descriptions);
 		
-		DescriptionUDT description2 = new DescriptionUDT();
-		description2.name = "someName2";
-		description2.time = new Date();
+		 Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 
+		 dao.writeEntity(dataObject)
+		 .ifNotExists()
+		 .execute();
+		 
+		 DescriptionUDT description3 = new DescriptionUDT();
+		 description3.name = "someName3";
+		 description3.time = new Date();
+		 
+		 DescriptionUDT description4 = new DescriptionUDT();
+		 description4.name = "someName4";
+		 description4.time = new Date();
+		 
+		 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 
+		 BatchableWithTime<Write> update = dao
+		 		 .writeWithKey("id", dataObject.getId())
+		 		 .putMapValue("descriptions", "3", description3)
+				 .putMapValue("descriptions", "4", description4);
+		 update.execute();
 		
-		Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
-		descriptions.put("1", description1);
-		descriptions.put("2", description2);
+		 MockDOWithUDTMap entity = null;
+		 
+		 try {
+			 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+			 entity = dao.readWithKey("id", dataObject.getId())
+					 .asEntity(MockDOWithUDTMap.class)
+					 .execute().get();
+		 	
+		 }catch(Exception e) {
+			 e.printStackTrace();
+			 throw e;
+		 }
 		
-		dataObject.setDescriptions(descriptions);
-		
-		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-		
-		dao.writeEntity(dataObject)
-		.ifNotExists()
-		.execute();
-		
-		DescriptionUDT description3 = new DescriptionUDT();
-		description3.name = "someName3";
-		description3.time = new Date();
-		
-		DescriptionUDT description4 = new DescriptionUDT();
-		description4.name = "someName4";
-		description4.time = new Date();
-		
-		dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-		
-		BatchableWithTime<Write> update = dao
-				.writeWithKey("id", dataObject.getId())
-				.putMapValue("descriptions", "3", description3)
-				.putMapValue("descriptions", "4", description4);
-		update.execute();
-		
-		MockDOWithUDTMap entity = null;
-		
-		try {
-			dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-			entity = dao.readWithKey("id", dataObject.getId())
-					.asEntity(MockDOWithUDTMap.class)
-					.execute().get();
-			
-		}catch(Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
-		
-		assertNotNull(entity);
-		assertTrue(entity.getDescriptions().size() ==4);
-	}
+		 assertNotNull(entity);
+		 assertTrue(entity.getDescriptions().size() ==4);
+	 }
 	
-	/**
-	 * this method tests whether or not an update to a map entry
-	 * succeeds
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testUpdateObjectInMap() throws Exception {
-		MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
-		dataObject.setCreateDate(new Date());
-		dataObject.setId(System.currentTimeMillis()+"");
-		dataObject.setVersion(1);
+	 /**
+	  * this method tests whether or not an update to a map entry
+	  * succeeds
+	  * 
+	  * @throws Exception
+	  */
+	 @Test
+	 public void testUpdateObjectInMap() throws Exception {
+		 MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
+		 dataObject.setCreateDate(new Date());
+		 dataObject.setId(System.currentTimeMillis()+"");
+		 dataObject.setVersion(1);
+		 
+		 DescriptionUDT description1 = new DescriptionUDT();
+		 description1.name = "someName1";
+		 description1.time = new Date();
+		 
+		 DescriptionUDT description2 = new DescriptionUDT();
+		 description2.name = "someName2";
+		 description2.time = new Date();
+		 
+		 Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
+		 descriptions.put("1", description1);
+		 descriptions.put("2", description2);
+		 
+		 dataObject.setDescriptions(descriptions);
 		
-		DescriptionUDT description1 = new DescriptionUDT();
-		description1.name = "someName1";
-		description1.time = new Date();
+		 Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 
+		 dao.writeEntity(dataObject)
+		 .ifNotExists()
+		 .execute();
 		
-		DescriptionUDT description2 = new DescriptionUDT();
-		description2.name = "someName2";
-		description2.time = new Date();
+		 DescriptionUDT descriptionUpdate = new DescriptionUDT();
+		 descriptionUpdate.name = "updatedDescription2";
+		 descriptionUpdate.time = new Date();
+		 
 		
-		Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
-		descriptions.put("1", description1);
-		descriptions.put("2", description2);
+		 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
 		
-		dataObject.setDescriptions(descriptions);
+		 BatchableWithTime<Write> update = dao
+				 .writeWithKey("id", dataObject.getId())
+				 .putMapValue("descriptions", "2", descriptionUpdate);
+		 update.execute();
 		
-		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 MockDOWithUDTMap entity = null;
 		
-		dao.writeEntity(dataObject)
-		.ifNotExists()
-		.execute();
-		
-		DescriptionUDT descriptionUpdate = new DescriptionUDT();
-		descriptionUpdate.name = "updatedDescription2";
-		descriptionUpdate.time = new Date();
-		
-		
-		dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-		
-		BatchableWithTime<Write> update = dao
-				.writeWithKey("id", dataObject.getId())
-				.putMapValue("descriptions", "2", descriptionUpdate);
-		update.execute();
-		
-		MockDOWithUDTMap entity = null;
-		
-		try {
-			dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-			entity = dao.readWithKey("id", dataObject.getId())
-					.asEntity(MockDOWithUDTMap.class)
-					.execute().get();
+		 try {
+			 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+			 entity = dao.readWithKey("id", dataObject.getId())
+					 .asEntity(MockDOWithUDTMap.class)
+					 .execute().get();
 			
-			DescriptionUDT desc = entity.getDescriptions().get("2");
-			assertTrue("update was unsuccessful", "updatedDescription2".equals(desc.getName()));
-		}catch(Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
+			 DescriptionUDT desc = entity.getDescriptions().get("2");
+			 assertTrue("update was unsuccessful", "updatedDescription2".equals(desc.getName()));
+		 }catch(Exception e) {
+			 e.printStackTrace();
+			 throw e;
+		 }
 		
-		assertNotNull(entity);
+		 assertNotNull(entity);
 
-	}
+	 }
 	
-	/**
-	 * this method tests whether the new removeMapValue functionality 
-	 * succeeds
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testRemoveObjectsFromMap() throws Exception {
-		MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
-		dataObject.setCreateDate(new Date());
-		dataObject.setId(System.currentTimeMillis()+"");
-		dataObject.setVersion(1);
+	 /**
+	  * this method tests whether the new removeMapValue functionality 
+	  * succeeds
+	  * 
+	  * @throws Exception
+	  */
+	 @Test
+	 public void testRemoveObjectsFromMap() throws Exception {
+		 MockDOWithUDTMap dataObject = new MockDOWithUDTMap();
+		 dataObject.setCreateDate(new Date());
+		 dataObject.setId(System.currentTimeMillis()+"");
+		 dataObject.setVersion(1);
+		 
+		 DescriptionUDT description1 = new DescriptionUDT();
+		 description1.name = "someName1";
+		 description1.time = new Date();
 		
-		DescriptionUDT description1 = new DescriptionUDT();
-		description1.name = "someName1";
-		description1.time = new Date();
+		 DescriptionUDT description2 = new DescriptionUDT();
+		 description2.name = "someName2";
+		 description2.time = new Date();
 		
-		DescriptionUDT description2 = new DescriptionUDT();
-		description2.name = "someName2";
-		description2.time = new Date();
+		 DescriptionUDT description3 = new DescriptionUDT();
+		 description3.name = "someName3";
+		 description3.time = new Date();
 		
-		DescriptionUDT description3 = new DescriptionUDT();
-		description3.name = "someName3";
-		description3.time = new Date();
+		 DescriptionUDT description4 = new DescriptionUDT();
+		 description4.name = "someName4";
+		 description4.time = new Date();
 		
-		DescriptionUDT description4 = new DescriptionUDT();
-		description4.name = "someName4";
-		description4.time = new Date();
+		 Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
+		 descriptions.put("1", description1);
+		 descriptions.put("2", description2);
+		 descriptions.put("3", description3);
+		 descriptions.put("4", description4);
 		
-		Map<String, DescriptionUDT> descriptions = new HashMap<String, DescriptionUDT>();
-		descriptions.put("1", description1);
-		descriptions.put("2", description2);
-		descriptions.put("3", description3);
-		descriptions.put("4", description4);
+		 dataObject.setDescriptions(descriptions);
 		
-		dataObject.setDescriptions(descriptions);
+		 Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
 		
-		Dao dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-		
-		dao.writeEntity(dataObject)
-		.ifNotExists()
-		.execute();
+		 dao.writeEntity(dataObject)
+		 .ifNotExists()
+		 .execute();
 
 		
-		dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+		 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
 		
-		Deletion deletion = dao
-				.deleteWithKey("id", dataObject.getId())
-				.removeMapValue("descriptions", "2")
-				.removeMapValue("descriptions", "4");
-		deletion.execute();
+		 Deletion deletion = dao
+				 .deleteWithKey("id", dataObject.getId())
+				 .removeMapValue("descriptions", "2")
+				 .removeMapValue("descriptions", "4");
+		 deletion.execute();
 		
-		MockDOWithUDTMap entity = null;
-		//test change
-		try {
-			dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
-			entity = dao.readWithKey("id", dataObject.getId())
-					.asEntity(MockDOWithUDTMap.class)
-					.execute().get();
+		 MockDOWithUDTMap entity = null;
+		
+		 try {
+			 dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
+			 entity = dao.readWithKey("id", dataObject.getId())
+					 .asEntity(MockDOWithUDTMap.class)
+					 .execute().get();
 			
-		}catch(Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
+		 }catch(Exception e) {
+			 e.printStackTrace();
+			 throw e;
+		 }
 		
-		assertNotNull(entity);
-		assertTrue(entity.getDescriptions().size() ==2);
-	}
+		 assertNotNull(entity);
+		 assertTrue(entity.getDescriptions().size() ==2);
+	 }
 	
 	// Tests @Field shows up on subclasses
 	abstract public static class AbstractDO {

--- a/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
@@ -444,7 +444,7 @@ public class UDTValueMappingCollectionTests extends TestCase {
 		deletion.execute();
 		
 		MockDOWithUDTMap entity = null;
-		
+		//test change
 		try {
 			dao = new DaoImpl(session, keyspace, TABLE_MOCK_WITH_UDT_MAP);
 			entity = dao.readWithKey("id", dataObject.getId())

--- a/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
+++ b/troilus-core/src/test/java/net/oneandone/troilus/userdefinieddatatypes/UDTValueMappingCollectionTests.java
@@ -261,6 +261,7 @@ public class UDTValueMappingCollectionTests extends TestCase {
 	 	
 	 }
 	
+	 
 	 /**
 	  * this method tests that the change to add an entry into a map 
 	  * succeeds
@@ -460,6 +461,8 @@ public class UDTValueMappingCollectionTests extends TestCase {
 		 assertTrue(entity.getDescriptions().size() ==2);
 	 }
 	
+	 
+	 
 	// Tests @Field shows up on subclasses
 	abstract public static class AbstractDO {
 		


### PR DESCRIPTION
Hello -

We've been working with your API's and have really enjoyed the work you've done.  I'm a co-worker of Jason Westra (jwestra) who has recently submitted a few changes back in December.  As we are really starting to dive into the Troilus API and integrate our application, a need recently surfaced to be able to add/update/remove User Defined Types from map datatypes (ie: map<text, frozen<SomeCustomUDT>>).  I am able to successfully execute an Insertion with an entity that contains a map type that contains a UDT value, but I've ran into a few issues performing an update (add/update/remove) to a map with a UDT value.  

When using the Write.putMapValue(...) method, I was able to successfully update a map type if the map value was a standard data type such as "text" or "boolean" (ie: map<text, text> ), but was unable to execute the putMapValue for a value that is a UDT (ie: map<text, frozen<SomeCustomUDT>>).  It seems that there is an issue in the WriteQueryDataImpl.toUpdateStatementAsync(...) method.  In short, the problem was that when the code was iterating through the mapValuesToMutate, it was trying to convert the "mapKey" value  (ie: putMapValue("yourcolumnName", "mapKey", mapValue)) into a UDTValue in the UDTValueMapper.toUdtValue method.   This method is expecting a Map<Object, Object> so inevitably, we were hitting a ClassCastException.  Please see the updates for review as a fix for this issue.  

In addition to the Write API, I wanted to be able to delete map entries from a column family with a type of map.  I've added support for this functionality in the DeleteQueryDataImpl and related files so that we can now execute a Deletion to remove map entries with a simple call to say --> Deletion.removeMapValue("columnName", "mapKeyToRemove").

On a side note, after making these changes, upon reviewing the code, we also noticed that all statements are being cached.  I wanted to bring this up to you as a topic for discussion as we are wondering whether or not it makes sense to cache a prepared statement that contains a Collection or Map column.  The reason for concern is that since a List, Set or Map column can contain one or many values, we were concerned that we would be caching a myriad of statements as the number of add/update/remove requests flow through the API.  So for example, a user adds 3 map entries in one statement... moments later another 2 map entries are added... and then again someone adds another entry to the map.  It would appear that we would now have 3 cached statements.  Maybe we are over thinking things, but is this a cause for concern?  If a statement is somewhat unusable after it executes, is there a way that we may introduce a way to opt out of caching a particular statement?  For instance, one suggestion would be to modify the DBSession.prepareAsync(..) method to take a boolean that can flag statements that we do not want to cache or better yet introduce a new method that simply does not cache.

At any rate, you're input is valued and thank you for all of your efforts!  Per your comments to Jason, I've added a .gitAttributes file to hopefully convert our Windows based CRLF file formats into LF to make life easier when reviewing the changeset.  I've also adjusted my IDE to insert spaces for tabs to also help your cause.  I did run into a few issues as the CRLF values were not converted to LF.  I reverted my changes and then re-added them.  I am hoping that makes it easy for you to see the changeset.  My apologies if this is not the case.  For potential future updates, maybe we can discuss the best approach to make sure we send you any updates in the format that makes it seamless for your review.

thanks!
Mike
